### PR TITLE
Improve accessibility of icon-only buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <button @click="showImportModal = true" class="btn"><i data-feather="upload" class="w-4 h-4"></i><span>Import</span></button>
         <button @click="exportData" class="btn"><i data-feather="download" class="w-4 h-4"></i><span>Export</span></button>
         <button @click="clearAllData" class="btn"><i data-feather="trash-2" class="w-4 h-4"></i><span>Clear</span></button>
-        <button @click="toggleDarkMode()" class="btn"><i :data-feather="darkMode ? 'sun' : 'moon'"></i></button>
+        <button @click="toggleDarkMode()" class="btn" aria-label="Toggle dark mode"><i :data-feather="darkMode ? 'sun' : 'moon'"></i></button>
       </div>
     </div>
 
@@ -77,7 +77,7 @@
                     <span x-text="req.name" class="font-semibold"></span>
                     <div class="flex items-center gap-1">
                       <span x-show="req.defaultExpiryDays" class="text-xs opacity-75" x-text="`${Math.floor(req.defaultExpiryDays/365)}y`"></span>
-                      <button @click="editRequirement(req)" class="opacity-50 hover:opacity-100 transition-opacity">
+                      <button @click="editRequirement(req)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Edit requirement ${req.name}`">
                         <i data-feather="edit-2" class="w-3 h-3"></i>
                       </button>
                     </div>
@@ -99,7 +99,7 @@
                     <div class="flex items-center gap-1">
                       <span :class="emp.status === 'Active' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'" 
                             class="status-badge px-2 py-1 text-xs rounded-full" x-text="emp.status"></span>
-                      <button @click="editEmployee(emp)" class="opacity-50 hover:opacity-100 transition-opacity">
+                      <button @click="editEmployee(emp)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Edit employee ${emp.firstName} ${emp.lastName}`">
                         <i data-feather="edit-2" class="w-3 h-3"></i>
                       </button>
                     </div>


### PR DESCRIPTION
## Summary
- add aria-label to dark-mode toggle button
- provide descriptive aria-labels for requirement and employee edit buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c119718f348327b1b6e1c3e8bd5d3c