### PR TITLE
feat: add error details in status toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -747,7 +747,11 @@
             console.log('Toggle completed');
           } catch (error) {
             console.error('Error toggling status:', error);
-            this.notify('Error updating status. Please try again.', 'var(--danger)');
+            if (error && error.stack) {
+              console.error(error.stack);
+            }
+            const message = error && error.message ? `Error updating status: ${String(error.message)}` : 'Error updating status. Please try again.';
+            this.notify(message, 'var(--danger)');
           }
         },
 


### PR DESCRIPTION
## Summary
- show error.message when status toggle fails
- log the error stack to aid debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c11cb2da3c8327a2b6f13d6b76b73a