### PR TITLE
Simplify status toggling logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -731,18 +731,15 @@
             const newStatus = er && er.status === 'Completed' ? 'NotCompleted' : 'Completed';
             console.log('Current status:', er?.status, 'New status:', newStatus);
 
-            await this.db.transaction('rw', this.db.employeeRequirements, async () => {
-              const record = {
-                id: er?.id || generateId(),
-                employeeId: emp.id,
-                requirementId: req.id,
-                status: newStatus,
-                completedOn: newStatus === 'Completed' ? new Date().toISOString().slice(0,10) : null,
-                updatedAt: new Date().toISOString()
-              };
-              await this.db.employeeRequirements.put(record);
-            });
-
+            const record = {
+              id: er?.id || generateId(),
+              employeeId: emp.id,
+              requirementId: req.id,
+              status: newStatus,
+              completedOn: newStatus === 'Completed' ? new Date().toISOString().slice(0,10) : null,
+              updatedAt: new Date().toISOString()
+            };
+            await this.db.employeeRequirements.put(record);
             await this.loadData();
             console.log('Toggle completed');
           } catch (error) {


### PR DESCRIPTION
## Summary
- remove Dexie transaction wrapper in `toggleStatus`
- directly insert updated record then reload data

## Testing
- `node verify.js` *(failed: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c11d6ea76c8327968db54238114283