### PR TITLE
Improve checkbox accessibility with focus outlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
     .sticky-col{position:sticky;left:0;z-index:10;background:var(--card)}
     .checkbox{appearance:none;width:1.25rem;height:1.25rem;border:2px solid var(--line);border-radius:.25rem;cursor:pointer;position:relative;background:var(--card);transition:all 0.2s ease;display:inline-block}
     .checkbox:hover{transform:scale(1.1);box-shadow:0 2px 4px rgba(0,0,0,0.1)}
+    .checkbox:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
     .checkbox.completed{background-color:var(--success);border-color:var(--success)}
     .checkbox.expired{background-color:var(--warn);border-color:var(--warn)}
     .checkbox.completed::after{content:"";position:absolute;left:50%;top:50%;transform:translate(-50%,-60%) rotate(-45deg);width:.75rem;height:.4rem;border-left:2px solid #fff;border-bottom:2px solid #fff}
@@ -112,7 +113,8 @@
                         :class="{ 'completed': getStatus(emp.id, req.id) === 'Completed', 'expired': getStatus(emp.id, req.id) === 'Expired' }"
                         :checked="getStatus(emp.id, req.id) === 'Completed'"
                         @change="toggleStatus(emp, req)"
-                        :title="getStatusTooltip(emp.id, req.id)">
+                        :title="getStatusTooltip(emp.id, req.id)"
+                        :aria-label="`${req.name} requirement for ${emp.firstName} ${emp.lastName}`">
                     </div>
                   </td>
                 </template>


### PR DESCRIPTION
## Summary
- highlight requirement checkboxes when navigating by keyboard
- add aria labels that describe the employee and requirement for each checkbox

## Testing
- `npx htmlhint@latest index.html`
- `npx --yes pa11y@latest index.html` *(fails: error while loading shared libraries: libcups.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c11e5d77a88327ac97aa3e85bf6d39