### PR TITLE
chore: bump service worker cache version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@
 - **Dry Run:** Shows how many rows will be added/updated and lists first skipped reasons.
 - **Post-Import Result:** Toast shows added/updated counts; also displays total employees now in the DB.
 - **Clear All Data:** For quick re-tests.
+- **Clear Cache:** Visit `/clear-cache.html` to wipe service worker and browser caches.
 
 Deploy: Netlify build command = empty; publish dir = `.`

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE='cmatrix-v4_4';
+const CACHE='cmatrix-v4_5';
 const ASSETS=['/','/index.html','/manifest.webmanifest','/styles.css','/icon-192.svg','/icon-512.svg'];
 self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS)))});
 self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))) });


### PR DESCRIPTION
## Summary
- bump service worker cache to `cmatrix-v4_5` so browsers install the latest index
- document `/clear-cache.html` helper for wiping local caches

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1212f678083279283f66f7aff5823