### PR TITLE
Fix modal layering so dialogs sit above overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,9 +196,9 @@
   <!-- Add Employee Modal -->
   <div x-show="showAddEmployeeModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showAddEmployeeModal=false" class="fixed inset-0 bg-black/40"></div>
+      <div @click="showAddEmployeeModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
-      <div class="inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <h3 class="text-lg font-semibold mb-4">Add New Employee</h3>
           <div class="space-y-4">
@@ -253,9 +253,9 @@
   <!-- Add Requirement Modal -->
   <div x-show="showAddRequirementModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showAddRequirementModal=false" class="fixed inset-0 bg-black/40"></div>
+      <div @click="showAddRequirementModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
-      <div class="inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <h3 class="text-lg font-semibold mb-4">Add New Requirement</h3>
           <div class="space-y-4">
@@ -298,9 +298,9 @@
   <!-- Edit Requirement Modal -->
   <div x-show="showEditRequirementModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showEditRequirementModal=false" class="fixed inset-0 bg-black/40"></div>
+      <div @click="showEditRequirementModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
-      <div class="inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <h3 class="text-lg font-semibold mb-4">Edit Requirement</h3>
           <div class="space-y-4">
@@ -343,9 +343,9 @@
   <!-- Edit Employee Modal -->
   <div x-show="showEditEmployeeModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showEditEmployeeModal=false" class="fixed inset-0 bg-black/40"></div>
+      <div @click="showEditEmployeeModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
-      <div class="inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <h3 class="text-lg font-semibold mb-4">Edit Employee</h3>
           <div class="space-y-4">
@@ -400,9 +400,9 @@
   <!-- Bulk Actions Modal -->
   <div x-show="showBulkActionsModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showBulkActionsModal=false" class="fixed inset-0 bg-black/40"></div>
+      <div @click="showBulkActionsModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
-      <div class="inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <h3 class="text-lg font-semibold mb-4">Bulk Actions</h3>
           <div class="space-y-4">
@@ -452,9 +452,9 @@
   <!-- Import Modal -->
   <div x-show="showImportModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showImportModal=false" class="fixed inset-0 bg-black/40"></div>
+      <div @click="showImportModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
-      <div class="inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
           <div class="flex items-center justify-between">
             <h3 class="text-lg font-semibold mb-3">Import Data</h3>


### PR DESCRIPTION
## Summary
- ensure each modal overlay uses lower z-index
- raise modal containers with `relative z-50` for proper stacking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1234f2aac8327920bb5d5862d1fbc