### PR TITLE
Add requirement deletion with undo toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,10 @@
                     <div class="flex items-center gap-1">
                       <span x-show="req.defaultExpiryDays" class="text-xs opacity-75" x-text="`${Math.floor(req.defaultExpiryDays/365)}y`"></span>
                       <button @click="editRequirement(req)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Edit requirement ${req.name}`">
-                        <i data-feather="edit-2" class="w-3 h-3"></i>
+                        <i data-feather="edit-2" class="w-2 h-2"></i>
+                      </button>
+                      <button @click="confirmDeleteRequirement(req)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Delete requirement ${req.name}`">
+                        <i data-feather="trash-2" class="w-3 h-3"></i>
                       </button>
                     </div>
                   </div>
@@ -101,7 +104,7 @@
                       <span :class="emp.status === 'Active' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'" 
                             class="status-badge px-2 py-1 text-xs rounded-full" x-text="emp.status"></span>
                       <button @click="editEmployee(emp)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Edit employee ${emp.firstName} ${emp.lastName}`">
-                        <i data-feather="edit-2" class="w-3 h-3"></i>
+                        <i data-feather="edit-2" class="w-2 h-2"></i>
                       </button>
                     </div>
                   </div>
@@ -621,6 +624,7 @@
 
   <div x-show="showToast" class="fixed bottom-4 right-4 px-4 py-2 rounded shadow-lg" :style="'background:'+toastColor+';color:white'">
     <span x-text="toastMessage"></span>
+    <button x-show="toastUndo" @click="toastUndo()" class="ml-3 underline font-semibold">Undo</button>
   </div>
 
   <script>
@@ -638,7 +642,8 @@
         darkMode:false, showImportModal:false,
         db:null, employees:[], requirements:[], employeeRequirements:[], erMap:new Map(), visibleRequirements:[],
         // Toast notification variables
-        showToast: false, toastMessage: '', toastColor: 'var(--success)',
+        showToast: false, toastMessage: '', toastColor: 'var(--success)', toastUndo:null,
+        lastDeletedRequirement:null,
         // Import UI state
         importType:'excel', importMode:'employees', importData:[], importHeaders:[], importSheets:[], importSheetName:'', importWarning:'', importError:'', importLoading:false,
         nameFormat:'auto', previewEligible:0, dryRunDetails:[], dryRunSummary:{added:0,updated:0,skipped:0},
@@ -755,7 +760,13 @@
         },
 
         // UI helpers
-        notify(msg,color='var(--success)'){ this.toastMessage=msg; this.toastColor=color; this.showToast=true; setTimeout(()=>this.showToast=false,3000); },
+        notify(msg,color='var(--success)',undoHandler=null){
+          this.toastMessage=msg;
+          this.toastColor=color;
+          this.toastUndo=undoHandler;
+          this.showToast=true;
+          setTimeout(()=>{this.showToast=false; this.toastUndo=null;},3000);
+        },
         async toggleDarkMode(){ this.darkMode=!this.darkMode; document.documentElement.classList.toggle('dark', this.darkMode); const prev=await this.db.settings.get('app')||{id:'app'}; await this.db.settings.put({...prev, darkMode:this.darkMode}); },
         initializeFeatherIcons() {
           try {
@@ -1287,6 +1298,32 @@
           await this.loadData();
           this.refreshFeatherIcons();
           this.notify('Requirement updated');
+        },
+        confirmDeleteRequirement(req){
+          if(confirm(`Delete requirement "${req.name}"? This will remove all related records.`)){
+            this.deleteRequirement(req);
+          }
+        },
+        async deleteRequirement(req){
+          const related = await this.db.employeeRequirements.where('requirementId').equals(req.id).toArray();
+          this.lastDeletedRequirement = { requirement: req, employeeRequirements: related };
+          await this.db.requirements.delete(req.id);
+          await this.db.employeeRequirements.where('requirementId').equals(req.id).delete();
+          await this.loadData();
+          this.refreshFeatherIcons();
+          this.notify('Requirement deleted','var(--warn)',() => this.undoDeleteRequirement());
+        },
+        async undoDeleteRequirement(){
+          if(!this.lastDeletedRequirement) return;
+          await this.db.requirements.add(this.lastDeletedRequirement.requirement);
+          if(this.lastDeletedRequirement.employeeRequirements.length){
+            await this.db.employeeRequirements.bulkAdd(this.lastDeletedRequirement.employeeRequirements);
+          }
+          this.lastDeletedRequirement=null;
+          this.toastUndo=null;
+          await this.loadData();
+          this.refreshFeatherIcons();
+          this.notify('Requirement restored');
         },
         async editEmployee(emp){
           this.editingEmployee = { ...emp, seniorityHours: emp.seniorityHours ?? '' };


### PR DESCRIPTION
## Summary
- Add trash button for requirements with confirmation
- Support undoable requirement deletion and restoration
- Extend toast to show Undo actions
- Shrink edit icons for a more compact UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12569b9f48327b199a85333936b6d