### PR TITLE
Add employee sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,30 @@
         <table class="min-w-full divide-y" style="border-color:var(--line)">
           <thead class="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th class="sticky-col px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color:var(--muted)">Employee</th>
+              <th @click="sortEmployees('firstName')" class="sticky-col px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer" style="color:var(--muted)">
+                <div class="flex items-center">
+                  <span>Employee</span>
+                  <span x-show="sortField==='firstName'" x-text="sortDirection==='asc' ? '▲' : '▼'" class="ml-1"></span>
+                </div>
+              </th>
+              <th @click="sortEmployees('role')" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer" style="color:var(--muted)">
+                <div class="flex items-center">
+                  <span>Role</span>
+                  <span x-show="sortField==='role'" x-text="sortDirection==='asc' ? '▲' : '▼'" class="ml-1"></span>
+                </div>
+              </th>
+              <th @click="sortEmployees('employmentType')" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer" style="color:var(--muted)">
+                <div class="flex items-center">
+                  <span>Type</span>
+                  <span x-show="sortField==='employmentType'" x-text="sortDirection==='asc' ? '▲' : '▼'" class="ml-1"></span>
+                </div>
+              </th>
+              <th @click="sortEmployees('status')" class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer" style="color:var(--muted)">
+                <div class="flex items-center">
+                  <span>Status</span>
+                  <span x-show="sortField==='status'" x-text="sortDirection==='asc' ? '▲' : '▼'" class="ml-1"></span>
+                </div>
+              </th>
               <template x-for="req in visibleRequirements" :key="req.id">
                 <th class="requirement-header px-4 py-3 text-left text-xs font-medium uppercase tracking-wider relative" :style="`background:${req.color || '#f8fafc'}; border-left: 3px solid ${req.color ? req.color.replace('f', '8').replace('e', '6') : '#94a3b8'};`">
                   <div class="flex items-center justify-between">
@@ -90,23 +113,23 @@
             </tr>
           </thead>
           <tbody class="divide-y virtual-scroll">
-            <template x-for="emp in (filteredEmployees.length ? filteredEmployees : employees)" :key="emp.id">
+            <template x-for="emp in sortedEmployees()" :key="emp.id">
               <tr class="hover:bg-gray-50 dark:hover:bg-gray-800">
                 <td class="sticky-col px-6 py-4">
                   <div class="flex items-center justify-between">
                     <div>
                       <div class="text-sm font-semibold" x-text="`${emp.firstName} ${emp.lastName}`"></div>
-                      <div class="text-xs" style="color:var(--muted)" x-text="`${emp.role||''} • ${emp.employmentType||''}`"></div>
                       <div x-show="emp.employeeId" class="text-xs" style="color:var(--muted)" x-text="`ID: ${emp.employeeId}`"></div>
                     </div>
-                    <div class="flex items-center gap-1">
-                      <span :class="emp.status === 'Active' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'" 
-                            class="status-badge px-2 py-1 text-xs rounded-full" x-text="emp.status"></span>
-                      <button @click="editEmployee(emp)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Edit employee ${emp.firstName} ${emp.lastName}`">
-                        <i data-feather="edit-2" class="icon-sm"></i>
-                      </button>
-                    </div>
+                    <button @click="editEmployee(emp)" class="opacity-50 hover:opacity-100 transition-opacity" :aria-label="`Edit employee ${emp.firstName} ${emp.lastName}`">
+                      <i data-feather="edit-2" class="icon-sm"></i>
+                    </button>
                   </div>
+                </td>
+                <td class="px-4 py-3 text-sm" x-text="emp.role"></td>
+                <td class="px-4 py-3 text-sm" x-text="emp.employmentType"></td>
+                <td class="px-4 py-3">
+                  <span :class="emp.status === 'Active' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'" class="status-badge px-2 py-1 text-xs rounded-full" x-text="emp.status"></span>
                 </td>
                 <template x-for="req in visibleRequirements" :key="req.id">
                   <td class="px-4 py-3">
@@ -654,7 +677,7 @@
         // Admin panel state
         showAddEmployeeModal:false, showAddRequirementModal:false, showBulkActionsModal:false,
         showEditEmployeeModal:false, showEditRequirementModal:false,
-        searchQuery:'', roleFilter:'', statusFilter:'', filteredEmployees:[],
+          searchQuery:'', roleFilter:'', statusFilter:'', filteredEmployees:[], sortField:'firstName', sortDirection:'asc',
         newEmployee:{firstName:'', lastName:'', role:'', employmentType:'FT', employeeId:'', seniorityHours:''},
         newRequirement:{name:'', defaultExpiryDays:'', color:'#e0e7ff'},
         editingEmployee:{}, editingRequirement:{},
@@ -1199,7 +1222,7 @@
           let filtered = [...this.employees];
           if (this.searchQuery) {
             const query = this.searchQuery.toLowerCase();
-            filtered = filtered.filter(emp => 
+            filtered = filtered.filter(emp =>
               emp.firstName.toLowerCase().includes(query) ||
               emp.lastName.toLowerCase().includes(query) ||
               emp.role.toLowerCase().includes(query) ||
@@ -1213,6 +1236,24 @@
             filtered = filtered.filter(emp => emp.status === this.statusFilter);
           }
           this.filteredEmployees = filtered;
+        },
+        sortEmployees(field){
+          if (this.sortField === field) {
+            this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+          } else {
+            this.sortField = field;
+            this.sortDirection = 'asc';
+          }
+        },
+        sortedEmployees(){
+          const arr = this.filteredEmployees.length ? [...this.filteredEmployees] : [...this.employees];
+          return arr.sort((a,b) => {
+            let aVal = (a[this.sortField] || '').toString().toLowerCase();
+            let bVal = (b[this.sortField] || '').toString().toLowerCase();
+            if (aVal < bVal) return this.sortDirection === 'asc' ? -1 : 1;
+            if (aVal > bVal) return this.sortDirection === 'asc' ? 1 : -1;
+            return 0;
+          });
         },
         async addEmployee(){
           if (!this.newEmployee.firstName || !this.newEmployee.lastName) {


### PR DESCRIPTION
## Summary
- add sort state and methods for employees
- enable sorting on employee table headers with direction indicators
- sort employee list based on selected field and direction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12f088bbc832797266bce4394516b