### PR TITLE
Add requirement column settings with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script>
     // Fallback for XLSX library loading
     if (typeof XLSX === 'undefined') {
@@ -59,6 +60,7 @@
         <button @click="showImportModal = true" class="btn"><i data-feather="upload" class="w-4 h-4"></i><span>Import</span></button>
         <button @click="exportData" class="btn"><i data-feather="download" class="w-4 h-4"></i><span>Export</span></button>
         <button @click="clearAllData" class="btn"><i data-feather="trash-2" class="w-4 h-4"></i><span>Clear</span></button>
+        <button @click="openSettingsModal()" class="btn"><i data-feather="settings" class="w-4 h-4"></i><span>Settings</span></button>
         <button @click="toggleDarkMode()" class="btn" aria-label="Toggle dark mode"><i :data-feather="darkMode ? 'sun' : 'moon'"></i></button>
       </div>
     </div>
@@ -96,7 +98,7 @@
                   <span x-show="sortField==='status'" x-text="sortDirection==='asc' ? '▲' : '▼'" class="ml-1"></span>
                 </div>
               </th>
-              <template x-for="req in visibleRequirements" :key="req.id">
+              <template x-for="req in orderedVisibleRequirements()" :key="req.id">
                 <th class="requirement-header px-4 py-3 text-left text-xs font-medium uppercase tracking-wider relative" :style="`background:${req.color || '#f8fafc'}; border-left: 3px solid ${req.color ? req.color.replace('f', '8').replace('e', '6') : '#94a3b8'};`">
                   <div class="flex items-center justify-between">
                     <span x-text="req.name" class="font-semibold"></span>
@@ -132,7 +134,7 @@
                 <td class="px-4 py-3">
                   <span :class="emp.status === 'Active' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'" class="status-badge px-2 py-1 text-xs rounded-full" x-text="emp.status"></span>
                 </td>
-                <template x-for="req in visibleRequirements" :key="req.id">
+                <template x-for="req in orderedVisibleRequirements()" :key="req.id">
                   <td class="px-4 py-3">
                     <div class="flex items-center justify-center">
                       <input type="checkbox" class="checkbox"
@@ -480,6 +482,34 @@
     </div>
   </div>
 
+  <!-- Settings Modal -->
+  <div x-show="showSettingsModal" class="fixed inset-0 z-50">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div @click="showSettingsModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
+      <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-md sm:w-full">
+        <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <h3 class="text-lg font-semibold mb-4">Column Settings</h3>
+          <ul x-ref="settingsList" class="space-y-2">
+            <template x-for="req in visibleRequirements" :key="req.id">
+              <li class="flex items-center justify-between p-2 border rounded" style="border-color:var(--line)">
+                <div class="flex items-center gap-2">
+                  <i data-feather="menu" class="w-4 h-4 handle cursor-move"></i>
+                  <span x-text="req.name"></span>
+                </div>
+                <input type="checkbox" x-model="req.visible" class="checkbox">
+              </li>
+            </template>
+          </ul>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-900 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button @click="saveAndCloseSettings" class="w-full sm:w-auto px-4 py-2 btn btn-primary">Save</button>
+          <button @click="showSettingsModal=false" class="mt-3 sm:mt-0 sm:ml-3 w-full sm:w-auto px-4 py-2 btn">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Import Modal -->
   <div x-show="showImportModal" class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
@@ -686,6 +716,7 @@
     document.addEventListener('alpine:init', () => {
       Alpine.data('app', () => ({
         darkMode:false, showImportModal:false,
+        showSettingsModal:false, settingsSortable:null,
         db:null, employees:[], requirements:[], employeeRequirements:[], erMap:new Map(), visibleRequirements:[],
         // Toast notification variables
         showToast: false, toastMessage: '', toastColor: 'var(--success)', toastUndo:null,
@@ -770,13 +801,65 @@
           this.requirements = await this.db.requirements.toArray();
           this.employeeRequirements = await this.db.employeeRequirements.toArray();
           this.erMap = new Map();
-            for (const er of this.employeeRequirements){
-              if(!this.erMap.has(er.employeeId)) this.erMap.set(er.employeeId,new Map());
-              this.erMap.get(er.employeeId).set(er.requirementId, er);
-            }
-            this.visibleRequirements = [...this.requirements];
-            this.renderComplianceChart();
-          },
+          for (const er of this.employeeRequirements){
+            if(!this.erMap.has(er.employeeId)) this.erMap.set(er.employeeId,new Map());
+            this.erMap.get(er.employeeId).set(er.requirementId, er);
+          }
+          await this.loadVisibleRequirements();
+          this.renderComplianceChart();
+        },
+
+        async loadVisibleRequirements(){
+          const setting = await this.db.settings.get('visibleRequirements');
+          if(setting && Array.isArray(setting.value)){
+            const map = new Map(setting.value.map(s => [s.id, s]));
+            this.visibleRequirements = this.requirements.map((r, idx) => {
+              const pref = map.get(r.id);
+              return { ...r, order: pref?.order ?? idx, visible: pref?.visible ?? true };
+            });
+            let changed = this.visibleRequirements.length !== setting.value.length;
+            this.visibleRequirements.sort((a,b) => a.order - b.order);
+            if(changed) await this.saveRequirementsSettings();
+          } else {
+            this.visibleRequirements = this.requirements.map((r, idx) => ({ ...r, order: idx, visible: true }));
+            await this.saveRequirementsSettings();
+          }
+        },
+
+        async saveRequirementsSettings(){
+          await this.db.settings.put({
+            id:'visibleRequirements',
+            value: this.visibleRequirements.map(r => ({id:r.id, order:r.order, visible:r.visible}))
+          });
+        },
+
+        orderedVisibleRequirements(){
+          return this.visibleRequirements.filter(r => r.visible).sort((a,b) => a.order - b.order);
+        },
+
+        openSettingsModal(){
+          this.showSettingsModal = true;
+          this.$nextTick(() => {
+            if(this.settingsSortable) this.settingsSortable.destroy();
+            this.settingsSortable = Sortable.create(this.$refs.settingsList, {
+              handle: '.handle',
+              animation: 150,
+              onEnd: (evt) => {
+                const moved = this.visibleRequirements.splice(evt.oldIndex,1)[0];
+                this.visibleRequirements.splice(evt.newIndex,0,moved);
+                this.visibleRequirements.forEach((r,i)=> r.order = i);
+              }
+            });
+            this.refreshFeatherIcons();
+          });
+        },
+
+        async saveAndCloseSettings(){
+          this.visibleRequirements.forEach((r,i)=> r.order=i);
+          await this.saveRequirementsSettings();
+          this.showSettingsModal = false;
+          this.refreshFeatherIcons();
+        },
 
         // Status helpers (minimal)
         getER(eId,rId){ return this.erMap.get(eId)?.get(rId) || null; },


### PR DESCRIPTION
## Summary
- Add SortableJS-powered settings modal to toggle requirement visibility and reorder columns
- Persist column order and visibility in IndexedDB so preferences survive reloads
- Render headers and rows based on saved column order

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1335965088327bf0fc07e06f16573