### PR TITLE
Add activity timeline with undo

### DIFF
--- a/activity-log.js
+++ b/activity-log.js
@@ -1,0 +1,55 @@
+// ActivityLog – simple audit trail with undo capability.
+export default class ActivityLog {
+  static async init(db) {
+    // Ensure the table exists before opening.
+    if (!db.tables.some(t => t.name === 'activityLog')) {
+      db.version(db.verno + 1).stores({
+        activityLog: 'id,timestamp,actionType'
+      });
+    }
+    await db.open();
+    return new ActivityLog(db);
+  }
+
+  constructor(db) {
+    this.db = db;
+    this.table = db.table('activityLog');
+  }
+
+  // Record a completed command.
+  async record({ actionType, actor, targets = [], metadata = {}, undoPayload }) {
+    const entry = {
+      id: crypto.randomUUID(),
+      timestamp: Date.now(),
+      actor,
+      actionType,
+      targets,
+      metadata,
+      undoPayload,
+      status: 'completed'
+    };
+    await this.table.add(entry);
+    return entry;
+  }
+
+  // Undo a previous action.
+  async undo(id, commandFactory) {
+    return this.db.transaction('rw', this.table, async () => {
+      const entry = await this.table.get(id);
+      if (!entry || entry.status !== 'completed') return;
+      const command = commandFactory(entry);
+      await command.undo(entry.undoPayload);
+      entry.status = 'undone';
+      await this.table.put(entry);
+    });
+  }
+
+  // Fetch most‑recent log entries.
+  async recent(limit = 20) {
+    return this.table
+      .orderBy('timestamp')
+      .reverse()
+      .limit(limit)
+      .toArray();
+  }
+}

--- a/commands.js
+++ b/commands.js
@@ -1,0 +1,75 @@
+// Command implementations used by the activity log.
+
+export class EditEmployee {
+  constructor(db, employeeId, newData) {
+    this.db = db;
+    this.employeeId = employeeId;
+    this.newData = newData;
+  }
+
+  async execute() {
+    const prev = await this.db.employees.get(this.employeeId);
+    await this.db.employees.update(this.employeeId, this.newData);
+    return { prev }; // payload for undo
+  }
+
+  async undo({ prev }) {
+    await this.db.employees.put(prev);
+  }
+}
+
+export class ImportEmployees {
+  constructor(db, rows) {
+    this.db = db;
+    this.rows = rows;
+  }
+
+  async execute() {
+    const ids = [];
+    const records = this.rows.map(row => {
+      const id = crypto.randomUUID();
+      ids.push(id);
+      return { id, ...row };
+    });
+    await this.db.employees.bulkAdd(records);
+    return { ids };
+  }
+
+  async undo({ ids }) {
+    await this.db.employees.bulkDelete(ids);
+  }
+}
+
+export class BulkUpdateStatus {
+  constructor(db, employeeIds, requirementId, status) {
+    this.db = db;
+    this.employeeIds = employeeIds;
+    this.requirementId = requirementId;
+    this.status = status;
+  }
+
+  async execute() {
+    const prev = [];
+    for (const employeeId of this.employeeIds) {
+      const key = [employeeId, this.requirementId];
+      const existing = await this.db.employeeRequirements.get(key);
+      prev.push({ employeeId, record: existing });
+      await this.db.employeeRequirements.put({
+        employeeId,
+        requirementId: this.requirementId,
+        status: this.status
+      });
+    }
+    return { prev };
+  }
+
+  async undo({ prev }) {
+    for (const { employeeId, record } of prev) {
+      if (record) {
+        await this.db.employeeRequirements.put(record);
+      } else {
+        await this.db.employeeRequirements.delete([employeeId, this.requirementId]);
+      }
+    }
+  }
+}

--- a/timeline-component.html
+++ b/timeline-component.html
@@ -1,0 +1,108 @@
+<div x-data="timeline()" x-init="init()">
+  <template x-for="entry in entries" :key="entry.id">
+    <div class="flex items-center space-x-2">
+      <span x-text="new Date(entry.timestamp).toLocaleString()"></span>
+      <span x-text="entry.actionType"></span>
+      <button x-show="entry.status === 'completed'" @click="undo(entry)">Undo</button>
+    </div>
+  </template>
+</div>
+
+<script type="module">
+import Dexie from 'dexie';
+import ActivityLog from './activity-log.js';
+import {
+  EditEmployee,
+  ImportEmployees,
+  BulkUpdateStatus
+} from './commands.js';
+
+export function timeline() {
+  return {
+    db: null,
+    activityLog: null,
+    entries: [],
+
+    async init() {
+      // Example schema—extend with your real tables.
+      this.db = new Dexie('app');
+      this.db.version(1).stores({
+        employees: 'id',
+        employeeRequirements: '[employeeId+requirementId],employeeId,requirementId,status',
+        activityLog: 'id,timestamp,actionType'
+      });
+      await this.db.open();
+      this.activityLog = await ActivityLog.init(this.db);
+      this.entries = await this.activityLog.recent();
+    },
+
+    async undo(entry) {
+      const factories = {
+        EditEmployee: e =>
+          new EditEmployee(this.db, e.targets[0], e.metadata.newData),
+        ImportEmployees: e =>
+          new ImportEmployees(this.db, e.metadata.rows),
+        BulkUpdateStatus: e =>
+          new BulkUpdateStatus(
+            this.db,
+            e.targets,
+            e.metadata.requirementId,
+            e.metadata.status
+          )
+      };
+      const factory = factories[entry.actionType];
+      if (!factory) return;
+      await this.activityLog.undo(entry.id, factory);
+      this.entries = await this.activityLog.recent();
+    }
+  };
+}
+
+/* ------------------------------------------------------------------
+   Example hooks showing how app actions integrate with ActivityLog.
+   Replace with actual UI handlers in your application.
+------------------------------------------------------------------ */
+
+export async function editEmployee(db, activityLog, employeeId, newData, actor) {
+  const cmd = new EditEmployee(db, employeeId, newData);
+  const undoPayload = await cmd.execute();
+  await activityLog.record({
+    actionType: 'EditEmployee',
+    actor,
+    targets: [employeeId],
+    metadata: { newData },
+    undoPayload
+  });
+}
+
+export async function importEmployees(db, activityLog, rows, actor) {
+  const cmd = new ImportEmployees(db, rows);
+  const undoPayload = await cmd.execute();
+  await activityLog.record({
+    actionType: 'ImportEmployees',
+    actor,
+    targets: [],          // IDs are in undoPayload.ids
+    metadata: { rows },
+    undoPayload
+  });
+}
+
+export async function bulkUpdateStatus(
+  db,
+  activityLog,
+  employeeIds,
+  requirementId,
+  status,
+  actor
+) {
+  const cmd = new BulkUpdateStatus(db, employeeIds, requirementId, status);
+  const undoPayload = await cmd.execute();
+  await activityLog.record({
+    actionType: 'BulkUpdateStatus',
+    actor,
+    targets: employeeIds,
+    metadata: { requirementId, status },
+    undoPayload
+  });
+}
+</script>


### PR DESCRIPTION
## Summary
- implement `ActivityLog` class to persist actions and undo them
- add command classes `EditEmployee`, `ImportEmployees`, and `BulkUpdateStatus`
- provide `timeline` Alpine.js component showing recent activity with undo hooks

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c145222558832795ace09c13c745d0