### PR TITLE
Handle trailing dashes in payroll names

### DIFF
--- a/index.html
+++ b/index.html
@@ -1345,13 +1345,17 @@
           let first = g('firstName'); let last = g('lastName');
           const payroll = g('payrollName');
           if ((!first || !last) && payroll){
-            const s = String(payroll).trim();
+            const s = String(payroll)
+              .replace(/\s*[-–—]+$/, '')
+              .trim();
             if (this.nameFormat==='last_first' || (this.nameFormat==='auto' && s.includes(','))){
               const parts = s.split(','); last = (parts[0]||'').trim(); first = (parts.slice(1).join(',')||'').trim();
             } else {
               const parts = s.split(/\\s+/);
               if (parts.length>=2){ first = parts[0].trim(); last = parts.slice(1).join(' ').trim(); }
             }
+            first = first.replace(/\s*[-–—]+$/, '').trim();
+            last  = last.replace(/\s*[-–—]+$/, '').trim();
           }
           return { first, last, role: g('role'), type: g('employmentType'), empId: g('employeeId'), status: g('status'), hours: g('seniorityHours') };
         },


### PR DESCRIPTION
## Summary
- Trim trailing dashes from payroll names before parsing
- Sanitize split first/last names to remove trailing dashes

## Testing
- `node autoMapColumns.test.js`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c1c76b17e08327bd961e502b5989f8