### PR TITLE
Add calendar view for requirement expirations

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Compliance Calendar</title>
+  <link rel="stylesheet" href="/styles.css?v=1">
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+  <style>
+    :root{ --bg:#f3f4f6; --card:#ffffff; --line:#e5e7eb; --text:#111827; --muted:#6b7280; --accent:#2563eb; --success:#10b981; --warn:#f59e0b; --danger:#ef4444; --badge-text:#111827; }
+    .dark:root, .dark{ --bg:#0b1220; --card:#111827; --line:#1f2937; --text:#f3f4f6; --muted:#9ca3af; --accent:#60a5fa; --success:#34d399; --warn:#fbbf24; --danger:#f87171; --badge-text:#111827; }
+    body{ background:var(--bg); color:var(--text); height:100vh; margin:0; }
+    #calendar{ width:100%; height:100%; }
+    .fc{ background:var(--card); color:var(--text); }
+    .fc-scrollgrid, .fc-theme-standard td, .fc-theme-standard th{ border-color:var(--line); }
+    .fc-event{ background:var(--accent); border-color:var(--accent); }
+  </style>
+  <script defer src="calendar.js"></script>
+</head>
+<body>
+  <div id="calendar"></div>
+</body>
+</html>

--- a/calendar.js
+++ b/calendar.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const db = new Dexie('ComplianceMatrixDB');
+  db.version(8).stores({
+    employees:'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
+    requirements:'id, name, defaultExpiryDays, color',
+    employeeRequirements:'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
+    settings:'id'
+  });
+
+  try {
+    const setting = await db.settings.get('app');
+    if (setting?.darkMode) {
+      document.documentElement.classList.add('dark');
+    }
+  } catch (e) {
+    console.error('Failed to load settings', e);
+  }
+
+  const [employees, requirements, employeeRequirements] = await Promise.all([
+    db.employees.toArray(),
+    db.requirements.toArray(),
+    db.employeeRequirements.toArray()
+  ]);
+
+  const empMap = new Map(employees.map(e => [e.id, e]));
+  const reqMap = new Map(requirements.map(r => [r.id, r]));
+
+  const events = employeeRequirements
+    .filter(er => er.expiresOn)
+    .map(er => {
+      const emp = empMap.get(er.employeeId);
+      const req = reqMap.get(er.requirementId);
+      return {
+        title: `${emp?.firstName ?? ''} ${emp?.lastName ?? ''} - ${req?.name ?? ''}`.trim(),
+        start: er.expiresOn,
+        allDay: true
+      };
+    });
+
+  const calendarEl = document.getElementById('calendar');
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'dayGridMonth',
+    height: '100%',
+    events
+  });
+  calendar.render();
+});

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
         </div>
         <button @click="clearAllData" class="btn"><i data-feather="trash-2" class="w-4 h-4"></i><span>Clear</span></button>
         <button id="activity-log-btn" @click="openActivityLog()" class="btn"><i data-feather="list" class="w-4 h-4"></i><span>Activity Log</span></button>
+        <button id="calendar-btn" @click="window.open('calendar.html', '_blank')" class="btn"><i data-feather="calendar" class="w-4 h-4"></i><span>Calendar</span></button>
         <button id="settings-btn" @click="openSettingsModal()" class="btn"><i data-feather="settings" class="w-4 h-4"></i><span>Settings</span></button>
         <button id="help-btn" @click="startTour()" class="btn"><i data-feather="help-circle" class="w-4 h-4"></i><span>Help</span></button>
         <button @click="toggleDarkMode()" class="btn" aria-label="Toggle dark mode"><i :data-feather="darkMode ? 'sun' : 'moon'"></i></button>


### PR DESCRIPTION
## Summary
- add Calendar button to toolbar opening new calendar view
- implement calendar.html with FullCalendar and theme variables
- load requirement expiration dates from Dexie in calendar.js

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fbf74848832793b45f58e819f3c6