### PR TITLE
Guard activity timeline load until DB ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -802,10 +802,25 @@
       return {
         entries: [],
         async load(){
-          const { default: ActivityLog } = await import('./activity-log.js');
-          if(!this.$root.activityLog){
-            this.$root.activityLog = await ActivityLog.init(this.$root.db);
+          if(!this?.$root?.db){
+            this.$nextTick(() => this.load());
+            return;
           }
+
+          const { default: ActivityLog } = await import('./activity-log.js');
+
+          if(!this.$root.activityLog){
+            if(typeof this.$root.initActivityLog === 'function'){
+              await this.$root.initActivityLog();
+            }
+
+            if(!this.$root.activityLog){
+              this.$root.activityLog = await ActivityLog.init(this.$root.db);
+            }
+          }
+
+          if(!this.$root.activityLog) return;
+
           this.entries = await this.$root.activityLog.recent();
         },
         async init(){


### PR DESCRIPTION
## Summary
- wait for the root database to exist before loading the activity timeline
- reuse the root initActivityLog helper before directly initializing the ActivityLog module
- prevent ActivityLog.init from being called with an undefined database reference

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cafaa8516c8327b321558af47108f5