### PR TITLE
Use relative asset URLs for PWA resources

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compliance Calendar</title>
-  <link rel="stylesheet" href="/styles.css?v=1">
+  <link rel="stylesheet" href="styles.css?v=1">
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>

--- a/convert-icons.html
+++ b/convert-icons.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PWA Icon Converter</title>
-  <link rel="stylesheet" href="/styles.css?v=1">
+  <link rel="stylesheet" href="styles.css?v=1">
   <style>
     :root { --bg:#f3f4f6; --card:#ffffff; --line:#e5e7eb; --text:#111827; --muted:#6b7280; --accent:#2563eb; --success:#10b981; --warn:#f59e0b; --danger:#ef4444; }
     .dark:root, .dark { --bg:#0b1220; --card:#111827; --line:#1f2937; --text:#f3f4f6; --muted:#9ca3af; --accent:#60a5fa; --success:#34d399; --warn:#fbbf24; --danger:#f87171; }

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
   <meta http-equiv="Expires" content="0"/>
   <title>Compliance Matrix</title>
   <meta name="theme-color" content="#111827"/>
-  <link rel="manifest" href="/manifest.webmanifest?v=1"/>
+  <link rel="manifest" href="manifest.webmanifest?v=1"/>
   <!-- Production Tailwind CSS -->
-  <link rel="stylesheet" href="/styles.css?v=1">
+  <link rel="stylesheet" href="styles.css?v=1">
   <script src="https://unpkg.com/feather-icons"></script>
   <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
@@ -920,7 +920,7 @@
             }, 100);
           });
           
-          if ('serviceWorker' in navigator) try{ await navigator.serviceWorker.register('/sw.js?v=1'); }catch(e){}
+          if ('serviceWorker' in navigator) try{ await navigator.serviceWorker.register('sw.js?v=1'); }catch(e){}
 
           const tourSetting = await this.db.settings.get('hasSeenTour');
           if (!tourSetting?.value && typeof startTour === 'function') {

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,18 +1,18 @@
 {
   "name": "Compliance Matrix",
   "short_name": "Matrix",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#111827",
   "theme_color": "#111827",
   "icons": [
     {
-      "src": "/icon-192.svg?v=1",
+      "src": "icon-192.svg?v=1",
       "sizes": "192x192",
       "type": "image/svg+xml"
     },
     {
-      "src": "/icon-512.svg?v=1",
+      "src": "icon-512.svg?v=1",
       "sizes": "512x512",
       "type": "image/svg+xml"
     }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 const CACHE='cmatrix-v4_5';
-const ASSETS=['/','/index.html','/manifest.webmanifest','/styles.css','/icon-192.svg','/icon-512.svg'];
+const ASSETS=['./','index.html','manifest.webmanifest?v=1','styles.css?v=1','icon-192.svg?v=1','icon-512.svg?v=1'];
 self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS)))});
 self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))) });
 self.addEventListener('fetch',e=>{ 
@@ -16,7 +16,7 @@ self.addEventListener('fetch',e=>{
         return r; 
       }).catch(()=>{
         if(url.pathname.startsWith('/')) {
-          return caches.match('/index.html');
+          return caches.match('index.html').then(res=>res||caches.match('./'));
         }
         return Promise.reject('offline');
       });


### PR DESCRIPTION
## Summary
- switch PWA manifest, HTML entry points, and service worker to use relative asset URLs for better subdirectory support
- update service worker caching and registration to align with the new relative asset paths

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dab2a784708327919828ffc6a885e3