### PR TITLE
Adjust service worker asset handling for subdirectory deployment

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Compliance Calendar</title>
-  <link rel="stylesheet" href="/styles.css?v=1">
+  <link rel="stylesheet" href="styles.css?v=1">
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>

--- a/convert-icons.html
+++ b/convert-icons.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PWA Icon Converter</title>
-  <link rel="stylesheet" href="/styles.css?v=1">
+  <link rel="stylesheet" href="styles.css?v=1">
   <style>
     :root { --bg:#f3f4f6; --card:#ffffff; --line:#e5e7eb; --text:#111827; --muted:#6b7280; --accent:#2563eb; --success:#10b981; --warn:#f59e0b; --danger:#ef4444; }
     .dark:root, .dark { --bg:#0b1220; --card:#111827; --line:#1f2937; --text:#f3f4f6; --muted:#9ca3af; --accent:#60a5fa; --success:#34d399; --warn:#fbbf24; --danger:#f87171; }

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
   <meta http-equiv="Expires" content="0"/>
   <title>Compliance Matrix</title>
   <meta name="theme-color" content="#111827"/>
-  <link rel="manifest" href="/manifest.webmanifest?v=1"/>
+  <link rel="manifest" href="manifest.webmanifest?v=1"/>
   <!-- Production Tailwind CSS -->
-  <link rel="stylesheet" href="/styles.css?v=1">
+  <link rel="stylesheet" href="styles.css?v=1">
   <script src="https://unpkg.com/feather-icons"></script>
   <script src="https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
@@ -920,7 +920,6 @@
             }, 100);
           });
           
-          if ('serviceWorker' in navigator) try{ await navigator.serviceWorker.register('/sw.js?v=1'); }catch(e){}
 
           const tourSetting = await this.db.settings.get('hasSeenTour');
           if (!tourSetting?.value && typeof startTour === 'function') {
@@ -1937,6 +1936,13 @@
         }
       }));
     });
+  </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js?v=1').catch(() => {});
+      });
+    }
   </script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js" defer></script>
 </body>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,18 +1,18 @@
 {
   "name": "Compliance Matrix",
   "short_name": "Matrix",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#111827",
   "theme_color": "#111827",
   "icons": [
     {
-      "src": "/icon-192.svg?v=1",
+      "src": "icon-192.svg?v=1",
       "sizes": "192x192",
       "type": "image/svg+xml"
     },
     {
-      "src": "/icon-512.svg?v=1",
+      "src": "icon-512.svg?v=1",
       "sizes": "512x512",
       "type": "image/svg+xml"
     }

--- a/sw.js
+++ b/sw.js
@@ -1,22 +1,45 @@
-const CACHE='cmatrix-v4_5';
-const ASSETS=['/','/index.html','/manifest.webmanifest','/styles.css','/icon-192.svg','/icon-512.svg'];
-self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS)))});
-self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))) });
-self.addEventListener('fetch',e=>{ 
-  if(e.request.method!=='GET') return; 
-  const url=new URL(e.request.url);
-  e.respondWith(
-    caches.match(e.request).then(c=>{
-      if(c) return c;
-      return fetch(e.request).then(r=>{ 
-        if(url.origin===location.origin && r.ok) {
-          const responseClone = r.clone();
-          caches.open(CACHE).then(cs=>cs.put(e.request,responseClone));
+const CACHE = 'cmatrix-v4_5';
+const scopePath = self.registration.scope.replace(location.origin, '');
+const BASE = scopePath ? (scopePath.endsWith('/') ? scopePath : `${scopePath}/`) : '/';
+const withBase = (path = '') => `${BASE}${path.replace(/^\//, '')}`;
+const ASSET_PATHS = ['', 'index.html', 'manifest.webmanifest', 'styles.css', 'icon-192.svg', 'icon-512.svg'];
+const ASSETS = ASSET_PATHS.map(withBase);
+const OFFLINE_HTML = withBase('index.html');
+const OFFLINE_ROOT = withBase('');
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+
+  const url = new URL(event.request.url);
+  const inScope = url.origin === location.origin && url.pathname.startsWith(BASE);
+
+  event.respondWith(
+    caches.match(event.request).then(cacheResponse => {
+      if (cacheResponse) return cacheResponse;
+
+      return fetch(event.request).then(networkResponse => {
+        if (inScope && networkResponse.ok) {
+          const responseClone = networkResponse.clone();
+          caches.open(CACHE).then(cache => cache.put(event.request, responseClone));
         }
-        return r; 
-      }).catch(()=>{
-        if(url.pathname.startsWith('/')) {
-          return caches.match('/index.html');
+        return networkResponse;
+      }).catch(() => {
+        if (inScope) {
+          return caches.match(OFFLINE_HTML).then(response => response || caches.match(OFFLINE_ROOT));
         }
         return Promise.reject('offline');
       });


### PR DESCRIPTION
## Summary
- switch HTML manifest and stylesheet links to relative URLs so they resolve when the app is served from a subdirectory
- update the web manifest and service worker to derive asset paths from the registered scope and register the worker on page load
- ensure cache population and offline fallbacks respect the scoped base path

## Testing
- python -m http.server 8000
- playwright sync script verifying service worker scope and cache behaviour

------
https://chatgpt.com/codex/tasks/task_e_68dab1f368b483279e52bcc9293a0cb1