### PR TITLE
Fix ActivityLog initialization flow

### DIFF
--- a/activity-log.js
+++ b/activity-log.js
@@ -4,18 +4,21 @@ export default class ActivityLog {
     // Ensure the table exists before opening.
     if (!db.tables.some(t => t.name === 'activityLog')) {
       try {
-  db.version(db.verno + 1).stores({
-    activityLog: 'id,timestamp,actionType'
-  });
-} catch (e) {
-  // If version bump fails (e.g., another tab holds the DB), proceed to open and hope table exists.
-  console.warn('ActivityLog schema ensure failed (non-fatal):', e);
-}
-try {
-  await db.open();
-} catch (e) {
-  console.error('Failed to open DB for ActivityLog:', e);
-}
+        db.version(db.verno + 1).stores({
+          activityLog: 'id,timestamp,actionType'
+        });
+      } catch (e) {
+        // If version bump fails (e.g., another tab holds the DB), proceed to open and hope table exists.
+        console.warn('ActivityLog schema ensure failed (non-fatal):', e);
+      }
+    }
+
+    try {
+      await db.open();
+    } catch (e) {
+      console.error('Failed to open DB for ActivityLog:', e);
+    }
+
     return new ActivityLog(db);
   }
 


### PR DESCRIPTION
## Summary
- ensure the ActivityLog schema upgrade logic closes before the constructor definition
- open the database after checking for the table and always return a new ActivityLog instance

## Testing
- ⚠️ Unable to automate Activity Log modal check in headless browser (Alpine-driven UI remained cloaked in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dabec110a88327b49e43e112eaeb3b