### PR TITLE
Handle expiry dates for status updates

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -196,12 +196,13 @@ export class DeleteRequirement {
 }
 
 export class BulkUpdateStatus {
-  constructor(db, { employeeIds = [], requirementIds = [], status, completedOn = null } = {}) {
+  constructor(db, { employeeIds = [], requirementIds = [], status, completedOn = null, expiresOn = null } = {}) {
     this.db = db;
     this.employeeIds = employeeIds;
     this.requirementIds = requirementIds;
     this.status = status;
     this.completedOn = completedOn;
+    this.expiresOn = expiresOn;
   }
 
   async execute() {
@@ -211,6 +212,26 @@ export class BulkUpdateStatus {
 
     const changes = [];
     const timestamp = nowISO();
+    const resolveExpiresOn = (requirementId, fallback = null) => {
+      if (this.status !== 'Completed' || this.expiresOn == null) {
+        return this.status === 'Completed' ? fallback : null;
+      }
+      if (this.expiresOn instanceof Map) {
+        return this.expiresOn.has(requirementId)
+          ? (this.expiresOn.get(requirementId) ?? null)
+          : fallback;
+      }
+      if (typeof this.expiresOn === 'object' && !Array.isArray(this.expiresOn)) {
+        if (Object.prototype.hasOwnProperty.call(this.expiresOn, requirementId)) {
+          return this.expiresOn[requirementId] ?? null;
+        }
+        return fallback;
+      }
+      if (typeof this.expiresOn === 'string') {
+        return this.expiresOn;
+      }
+      return fallback;
+    };
 
     await this.db.transaction('rw', this.db.employeeRequirements, async () => {
       for (const employeeId of this.employeeIds) {
@@ -222,10 +243,11 @@ export class BulkUpdateStatus {
 
           if (existing) {
             changes.push({ type: 'update', record: clone(existing) });
+            const expiresOnValue = resolveExpiresOn(requirementId, existing.expiresOn ?? null);
             await this.db.employeeRequirements.update(existing.id, {
               status: this.status,
               completedOn: this.status === 'Completed' ? this.completedOn : null,
-              expiresOn: this.status === 'Completed' ? (existing.expiresOn || null) : null,
+              expiresOn: this.status === 'Completed' ? expiresOnValue : null,
               updatedAt: timestamp
             });
           } else {
@@ -235,7 +257,7 @@ export class BulkUpdateStatus {
               requirementId,
               status: this.status,
               completedOn: this.status === 'Completed' ? this.completedOn : null,
-              expiresOn: null,
+              expiresOn: this.status === 'Completed' ? resolveExpiresOn(requirementId, null) : null,
               notes: null,
               updatedAt: timestamp
             };

--- a/index.html
+++ b/index.html
@@ -1085,12 +1085,18 @@
             const newStatus = er && er.status === 'Completed' ? 'NotCompleted' : 'Completed';
             console.log('Current status:', er?.status, 'New status:', newStatus);
 
+            const completedOn = newStatus === 'Completed' ? new Date().toISOString().slice(0,10) : null;
+            const hasDefaultExpiry = req?.defaultExpiryDays !== undefined && req?.defaultExpiryDays !== null;
+            const expiresOn = newStatus === 'Completed'
+              ? (hasDefaultExpiry ? this.addDays(completedOn, req.defaultExpiryDays) : null)
+              : null;
             const record = {
               id: er?.id || generateId(),
               employeeId: emp.id,
               requirementId: req.id,
               status: newStatus,
-              completedOn: newStatus === 'Completed' ? new Date().toISOString().slice(0,10) : null,
+              completedOn,
+              expiresOn,
               updatedAt: new Date().toISOString()
             };
             await this.db.employeeRequirements.put(record);
@@ -1920,13 +1926,24 @@
             }
             const status = this.bulkAction === 'complete' ? 'Completed' : 'NotCompleted';
             const completedOn = this.bulkAction === 'complete' ? new Date().toISOString().slice(0,10) : null;
+            let expiresOn = null;
+            if (status === 'Completed') {
+              expiresOn = {};
+              for (const requirementId of this.selectedRequirements) {
+                const req = this.requirements.find(r => r.id === requirementId);
+                if (!req) continue;
+                const hasDefaultExpiry = req.defaultExpiryDays !== undefined && req.defaultExpiryDays !== null;
+                expiresOn[requirementId] = hasDefaultExpiry ? this.addDays(completedOn, req.defaultExpiryDays) : null;
+              }
+            }
             try{
               const { BulkUpdateStatus } = await import('./commands.js');
               const command = new BulkUpdateStatus(this.db, {
                 employeeIds: [...this.selectedEmployees],
                 requirementIds: [...this.selectedRequirements],
                 status,
-                completedOn
+                completedOn,
+                expiresOn
               });
               const undoPayload = await command.execute();
               if (undoPayload.changes?.length) {
@@ -1934,7 +1951,8 @@
                   employeeIds: [...this.selectedEmployees],
                   requirementIds: [...this.selectedRequirements],
                   status,
-                  completedOn
+                  completedOn,
+                  expiresOn
                 }, undoPayload);
               }
               this.notify(`Bulk ${this.bulkAction} completed for ${this.selectedEmployees.length} employees`);


### PR DESCRIPTION
## Summary
- calculate and store expiry dates when toggling requirement completions based on default expiry settings
- include per-requirement expiry dates in bulk completion updates and persist them through the BulkUpdateStatus command

## Testing
- Attempted to run browser-based verification of manual toggles and bulk completion, but CDN-hosted dependencies are blocked in the container environment

------
https://chatgpt.com/codex/tasks/task_e_68dac820aadc8327b20a1a904058330c