### PR TITLE
Add x-cloak to Alpine modals to prevent initial flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
   </div>
 
   <!-- Add Employee Modal -->
-  <div x-show="showAddEmployeeModal" class="fixed inset-0 z-50">
+  <div x-show="showAddEmployeeModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showAddEmployeeModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -341,7 +341,7 @@
   </div>
 
   <!-- Add Requirement Modal -->
-  <div x-show="showAddRequirementModal" class="fixed inset-0 z-50">
+  <div x-show="showAddRequirementModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showAddRequirementModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -386,7 +386,7 @@
   </div>
 
   <!-- Edit Requirement Modal -->
-  <div x-show="showEditRequirementModal" class="fixed inset-0 z-50">
+  <div x-show="showEditRequirementModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showEditRequirementModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -433,7 +433,7 @@
   </div>
 
   <!-- Edit Employee Modal -->
-  <div x-show="showEditEmployeeModal" class="fixed inset-0 z-50">
+  <div x-show="showEditEmployeeModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showEditEmployeeModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -490,7 +490,7 @@
   </div>
 
   <!-- Bulk Actions Modal -->
-  <div x-show="showBulkActionsModal" class="fixed inset-0 z-50">
+  <div x-show="showBulkActionsModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showBulkActionsModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -542,7 +542,7 @@
   </div>
 
   <!-- Settings Modal -->
-  <div x-show="showSettingsModal" class="fixed inset-0 z-50">
+  <div x-show="showSettingsModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showSettingsModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -570,7 +570,7 @@
   </div>
 
   <!-- Import Modal -->
-  <div x-show="showImportModal" class="fixed inset-0 z-50">
+  <div x-show="showImportModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showImportModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
@@ -759,7 +759,7 @@
   </div>
 
   <!-- Activity Log Modal -->
-  <div x-show="showActivityLogModal" class="fixed inset-0 z-50">
+  <div x-show="showActivityLogModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
       <div @click="showActivityLogModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>


### PR DESCRIPTION
## Summary
- add x-cloak to each Alpine modal wrapper so hidden before initialization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dacc7b21e88327aab732895414b088