### PR TITLE
Improve Alpine fallback watchdog

### DIFF
--- a/index.html
+++ b/index.html
@@ -2042,24 +2042,46 @@
   </script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js" defer></script>
   <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const hasAlpine = Boolean(window.Alpine) && Boolean(document.body?.__x);
+    function showFallback() {
+      document.body?.removeAttribute('x-cloak');
 
-      if (!hasAlpine) {
-        console.error('Alpine.js failed to load');
-
-        document.body?.removeAttribute('x-cloak');
-
-        const dashboard = document.getElementById('dashboard-app');
-        if (dashboard) {
-          dashboard.setAttribute('hidden', '');
-        }
-
-        const fallback = document.getElementById('alpine-fallback');
-        if (fallback) {
-          fallback.removeAttribute('hidden');
-        }
+      const dashboard = document.getElementById('dashboard-app');
+      if (dashboard) {
+        dashboard.setAttribute('hidden', '');
       }
+
+      const fallback = document.getElementById('alpine-fallback');
+      if (fallback) {
+        fallback.removeAttribute('hidden');
+      }
+    }
+
+    function hideFallback() {
+      const fallback = document.getElementById('alpine-fallback');
+      if (fallback && !fallback.hasAttribute('hidden')) {
+        fallback.setAttribute('hidden', '');
+      }
+
+      const dashboard = document.getElementById('dashboard-app');
+      if (dashboard) {
+        dashboard.removeAttribute('hidden');
+      }
+    }
+
+    document.addEventListener('alpine:initialized', () => {
+      hideFallback();
+    });
+
+    window.addEventListener('load', () => {
+      setTimeout(() => {
+        const rootStack = document.body ? document.body._x_dataStack : null;
+        const alpineReady = Boolean(window.Alpine) && Array.isArray(rootStack) && rootStack.length > 0;
+
+        if (!alpineReady) {
+          console.error('Alpine.js failed to initialize');
+          showFallback();
+        }
+      }, 1200);
     });
   </script>
   <script>


### PR DESCRIPTION
## Summary
- replace the DOMContentLoaded Alpine watchdog with explicit showFallback/hideFallback helpers
- wait for Alpine's `alpine:initialized` event to hide the fallback UI when the app boots successfully
- add a load-time timeout watchdog that triggers the fallback only if Alpine never attaches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf36e9ab48327b0b54af4ccc5c6bf