### PR TITLE
Handle special characters in global search highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -1765,9 +1765,17 @@
           this.globalSearch='';
           this.searchResults=[];
         },
+        getEscapedGlobalSearch(){
+          if(!this.globalSearch) return '';
+          return String(this.globalSearch).replace(/[.*+?^${}()|[\]\\]/g, '\$&');
+        },
         highlightText(text){
-          if(!this.globalSearch) return text;
-          return text.replace(new RegExp(`(${this.globalSearch})`, 'gi'), '<mark>$1</mark>');
+          if(text == null) return '';
+          const value = String(text);
+          if(!this.globalSearch) return value;
+          const escapedSearch = this.getEscapedGlobalSearch();
+          if(!escapedSearch) return value;
+          return value.replace(new RegExp(`(${escapedSearch})`, 'gi'), '<mark>$1</mark>');
         },
         sortEmployees(field){
           if (this.sortField === field) {


### PR DESCRIPTION
## Summary
- add an escape helper for the global search term and reuse it when highlighting text
- harden highlightText to guard against null values and skip regex work for empty searches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf72c58908327b40a5d19c7539288