### PR TITLE
Fix newline handling for CSV helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1406,14 +1406,16 @@
         downloadImportErrors(){
           if(!this.importErrors.length) return;
           const rows = [['Row','Error'], ...this.importErrors.map(e=>[e.row, e.message])];
-          const csv = rows.map(r=>r.map(v=>`"${String(v).replace(/"/g,'""')}"`).join(',')).join('\n');
+          const newline = '\n';
+          const csv = rows.map(r=>r.map(v=>`"${String(v).replace(/"/g,'""')}"`).join(',')).join(newline);
           const blob = new Blob([csv], {type:'text/csv'});
           this.downloadBlob(blob, 'import-errors.csv');
         },
         stripTitleLines(lines){
           let bestIdx=0, bestScore=-1;
           for(let i=0;i<Math.min(30,lines.length);i++){ const cols=(lines[i]||'').split(',').map(s=>s.replace(/\"/g,'').trim()); const sc=this.scoreHeaderRow(cols); if(sc>bestScore){bestScore=sc;bestIdx=i;} }
-          return lines.slice(bestIdx).join('\\n');
+          const newline = '\n';
+          return lines.slice(bestIdx).join(newline);
         },
         extractFromSheet(sheet){
           try {


### PR DESCRIPTION
## Summary
- ensure the import error CSV exporter joins rows using a newline character
- join the retained CSV content with newlines before passing the data to PapaParse

## Testing
- node - <<'NODE'
const rows = [['Row','Error'], [1,'Missing first name'], [2,'Missing last name']];
const newline = '\\n';
const csv = rows.map(r=>r.map(v=>`"${String(v).replace(/"/g,'""')}"`).join(',')).join(newline);
console.log(csv);
console.log('---');
console.log(csv.split('\\n').length);
NODE
- node - <<'NODE'
function stripTitleLines(lines){
  let bestIdx=0, bestScore=-1;
  for(let i=0;i<Math.min(30,lines.length);i++){
    const cols=(lines[i]||'').split(',').map(s=>s.replace(/\\"/g,'').trim());
    const sc=cols.length;
    if(sc>bestScore){bestScore=sc;bestIdx=i;}
  }
  const newline='\\n';
  return lines.slice(bestIdx).join(newline);
}
const lines = ['header1,header2', 'val1,val2', 'val3,val4'];
const stripped = stripTitleLines(lines);
console.log(stripped);
console.log('---');
console.log(stripped.split('\\n').length);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68dafff1e714832790112fd346d974f4