### PR TITLE
Ensure Alpine initializes after CDN load

### DIFF
--- a/index.html
+++ b/index.html
@@ -2050,7 +2050,11 @@
       }));
     });
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js" defer></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js"
+    defer
+    onload="window.Alpine && window.Alpine.start()"
+  ></script>
   <script>
     function showFallback() {
       document.body?.removeAttribute('x-cloak');


### PR DESCRIPTION
## Summary
- add an onload hook to the Alpine.js CDN script to explicitly start Alpine when it finishes loading

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db088d2618832791a4ac605acffcd5