### PR TITLE
Reset import column map between uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1330,6 +1330,8 @@
         // ---------- Import ----------
         async handleFileUpload(event){
           this.importError=''; this.importWarning=''; this.importData=[]; this.importHeaders=[]; this.importSheets=[]; this.importSheetName=''; this.previewEligible=0; this.dryRunDetails=[]; this.importLoading=true; this.importProgress=0; this.importErrors=[];
+          this.columnMap = { firstName:'', lastName:'', payrollName:'', role:'', employmentType:'', employeeId:'', status:'', seniorityHours:'' };
+          this.completionMap = {};
           const file = event.target.files[0];
           if(!file) { this.importLoading=false; return; }
           
@@ -1439,6 +1441,8 @@
           this.importError = '';
           this.importProgress = 0;
           this.importErrors = [];
+          this.columnMap = { firstName:'', lastName:'', payrollName:'', role:'', employmentType:'', employeeId:'', status:'', seniorityHours:'' };
+          this.completionMap = {};
           const reader = new FileReader();
           reader.onload = async (e) => {
             try {


### PR DESCRIPTION
## Summary
- reset the employee column mapping and completion mapping whenever a new file upload or worksheet selection begins
- allow `autoMapColumns` to repopulate mappings from the fresh headers to avoid stale associations between different uploads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd76cf44288327a1ef0f91f2b901af