### PR TITLE
Adjust global search width

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,14 +125,14 @@
     </div>
 
     <div class="fixed top-4 left-1/2 -translate-x-1/2 z-50">
-      <div class="relative" @keydown.escape.window="dismissSearchResults()">
+      <div class="relative w-72 md:w-96" @keydown.escape.window="dismissSearchResults()">
         <input
           id="global-search"
           x-model="globalSearch"
           @input="performGlobalSearch(globalSearch)"
           type="text"
           placeholder="Search..."
-          class="pl-3 pr-8 py-1 border rounded bg-white dark:bg-gray-800"
+          class="w-full pl-3 pr-8 py-1 border rounded bg-white dark:bg-gray-800"
           style="border-color:var(--line);"
         />
         <button


### PR DESCRIPTION
## Summary
- add responsive width utilities to the global search wrapper so it scales from 18rem to 24rem
- allow the search input to fill the wrapper width to keep the clear button aligned and maintain the search results panel positioning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7d4a25ec83278867f9810016e046