### PR TITLE
Align dark mode toggle icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
         <button id="calendar-btn" @click="window.open('calendar.html', '_blank')" class="btn"><i data-feather="calendar" class="w-4 h-4"></i><span>Calendar</span></button>
         <button id="settings-btn" @click="openSettingsModal()" class="btn"><i data-feather="settings" class="w-4 h-4"></i><span>Settings</span></button>
         <button id="help-btn" @click="beginTour()" class="btn" :class="{'help-highlight': highlightHelpButton}"><i data-feather="help-circle" class="w-4 h-4"></i><span>Help</span></button>
-        <button @click="toggleDarkMode()" class="btn" aria-label="Toggle dark mode"><i :data-feather="darkMode ? 'sun' : 'moon'"></i></button>
+        <button @click="toggleDarkMode()" class="btn" aria-label="Toggle dark mode"><i :data-feather="darkMode ? 'sun' : 'moon'" class="w-4 h-4"></i></button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add Tailwind width and height classes to the dark mode toggle icon for consistent sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7d50353c8327961de688b07e4396