### PR TITLE
Fix numeric and date sorting in employee table

### DIFF
--- a/index.html
+++ b/index.html
@@ -2561,9 +2561,46 @@
         sortedEmployees(){
           const source = this.isFiltering ? this.filteredEmployees : this.employees;
           const arr = [...source];
+          const field = this.sortField;
+
+          const numericFields = new Set(['seniorityHours', 'totalHours', 'completedCount', 'pendingCount']);
+          const dateFields = new Set(['createdAt', 'updatedAt', 'startDate', 'endDate', 'hireDate', 'expiresOn', 'completedOn', 'dueDate', 'timestamp']);
+
+          const normalize = (value) => {
+            if (value == null) return null;
+
+            if (value instanceof Date) {
+              const timestamp = value.getTime();
+              return Number.isNaN(timestamp) ? null : timestamp;
+            }
+
+            if (typeof value === 'number') {
+              return Number.isNaN(value) ? null : value;
+            }
+
+            if (numericFields.has(field)) {
+              const numberValue = typeof value === 'number'
+                ? value
+                : parseFloat(String(value).replace(/,/g, ''));
+              return Number.isNaN(numberValue) ? null : numberValue;
+            }
+
+            if (dateFields.has(field)) {
+              const timestamp = new Date(value).getTime();
+              return Number.isNaN(timestamp) ? null : timestamp;
+            }
+
+            return String(value).toLowerCase();
+          };
+
           return arr.sort((a,b) => {
-            let aVal = (a[this.sortField] || '').toString().toLowerCase();
-            let bVal = (b[this.sortField] || '').toString().toLowerCase();
+            const aVal = normalize(a[field]);
+            const bVal = normalize(b[field]);
+
+            if (aVal == null && bVal == null) return 0;
+            if (aVal == null) return this.sortDirection === 'asc' ? 1 : -1;
+            if (bVal == null) return this.sortDirection === 'asc' ? -1 : 1;
+
             if (aVal < bVal) return this.sortDirection === 'asc' ? -1 : 1;
             if (aVal > bVal) return this.sortDirection === 'asc' ? 1 : -1;
             return 0;


### PR DESCRIPTION
## Summary
- add a normalize helper in the employee sorter to coerce numeric and date values before comparing
- ensure undefined values fall to the end while keeping existing ascending/descending toggle logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb3a7bb388327ad5af2d6fcd35d39