### PR TITLE
Allow header action buttons to wrap on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
         <img src="icon-192.svg" alt="Maplewood icon" class="w-10 h-10 rounded-lg shadow-sm">
         <h1 class="text-2xl font-bold">Maplewood Compliance Matrix</h1>
       </div>
-      <div class="flex gap-2">
+      <div class="flex flex-wrap gap-2 gap-y-2 sm:flex-nowrap"><!-- Wrap intentionally enabled on small screens -->
         <button id="import-btn" @click="showImportModal = true" class="btn"><i data-feather="upload" class="w-4 h-4"></i><span>Import</span></button>
         <div class="relative">
           <button id="export-btn" @click="showExportDropdown = !showExportDropdown" class="btn"><i data-feather="download" class="w-4 h-4"></i><span>Export</span></button>


### PR DESCRIPTION
## Summary
- allow the header action buttons to wrap on smaller viewports to prevent overflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddfca5ab4483279eb88917da28d9a2