### PR TITLE
Add branded shell around calendar view

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -6,12 +6,15 @@
   <title>Compliance Calendar</title>
   <link rel="stylesheet" href="/styles.css?v=1">
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+  <script defer src="https://unpkg.com/feather-icons"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
   <style>
-    :root{ --bg:#f3f4f6; --card:#ffffff; --line:#e5e7eb; --text:#111827; --muted:#6b7280; --accent:#2563eb; --success:#10b981; --warn:#f59e0b; --danger:#ef4444; --badge-text:#111827; }
-    .dark:root, .dark{ --bg:#0b1220; --card:#111827; --line:#1f2937; --text:#f3f4f6; --muted:#9ca3af; --accent:#60a5fa; --success:#34d399; --warn:#fbbf24; --danger:#f87171; --badge-text:#111827; }
-    body{ background:var(--bg); color:var(--text); height:100vh; margin:0; }
+    :root{ --bg:#f3f4f6; --card:#ffffff; --line:#e5e7eb; --text:#111827; --muted:#6b7280; --accent:#2563eb; --success:#10b981; --expiring:#f97316; --warn:#f59e0b; --danger:#ef4444; --badge-text:#111827; }
+    .dark:root, .dark{ --bg:#0b1220; --card:#111827; --line:#1f2937; --text:#f3f4f6; --muted:#9ca3af; --accent:#60a5fa; --success:#34d399; --expiring:#fb923c; --warn:#fbbf24; --danger:#f87171; --badge-text:#111827; }
+    body{ background:var(--bg); color:var(--text); min-height:100vh; margin:0; }
+    .card{background:var(--card);border:1px solid var(--line)}
+    .btn{display:inline-flex;align-items:center;gap:.4rem;border-radius:.5rem;padding:.5rem .75rem;border:1px solid var(--line);background:var(--card);color:inherit;text-decoration:none}
     #calendar{ width:100%; height:100%; }
     .fc{ background:var(--card); color:var(--text); }
     .fc-scrollgrid, .fc-theme-standard td, .fc-theme-standard th{ border-color:var(--line); }
@@ -20,6 +23,28 @@
   <script defer src="calendar.js"></script>
 </head>
 <body>
-  <div id="calendar"></div>
+  <div class="container mx-auto px-4 py-6">
+    <header class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-6">
+      <!-- Mirrors the dashboard masthead to keep the calendar view on-brand -->
+      <div class="flex items-center gap-3">
+        <img src="icon-192.svg" alt="Maplewood icon" class="w-10 h-10 rounded-lg shadow-sm">
+        <h1 class="text-2xl font-bold">Maplewood Compliance Calendar</h1>
+      </div>
+      <a href="index.html" class="btn">
+        <i data-feather="arrow-left" class="w-4 h-4"></i>
+        <span>Back to Dashboard</span>
+      </a>
+    </header>
+    <div class="card rounded-lg shadow p-4">
+      <div id="calendar"></div>
+    </div>
+  </div>
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      if (window.feather) {
+        window.feather.replace();
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- align the calendar page shell with the dashboard styling, reusing shared variables and card treatments
- wrap the calendar grid in a branded container with masthead and navigation back to the dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddfecfd1948327b21fac2b208145bf