### PR TITLE
Apply Maplewood theme to cache helper page

### DIFF
--- a/clear-cache.html
+++ b/clear-cache.html
@@ -2,30 +2,42 @@
 <html>
 <head>
     <title>Clear Cache Helper</title>
+    <link rel="stylesheet" href="/styles.css?v=1">
     <style>
-        body { font-family: Arial, sans-serif; padding: 20px; }
-        button { padding: 10px 20px; margin: 10px; background: #2563eb; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        button:hover { background: #1d4ed8; }
-        .status { margin: 10px 0; padding: 10px; border-radius: 5px; }
-        .success { background: #dcfce7; color: #166534; }
-        .error { background: #fee2e2; color: #991b1b; }
+        /* Duplicated from index.html to keep parity with the main app. */
+        :root{ --bg:#f3f4f6; --card:#ffffff; --line:#e5e7eb; --text:#111827; --muted:#6b7280; --accent:#2563eb; --success:#10b981; --expiring:#f97316; --warn:#f59e0b; --danger:#ef4444; --badge-text:#111827; }
+        .dark:root, .dark{ --bg:#0b1220; --card:#111827; --line:#1f2937; --text:#f3f4f6; --muted:#9ca3af; --accent:#60a5fa; --success:#34d399; --expiring:#fb923c; --warn:#fbbf24; --danger:#f87171; --badge-text:#111827; }
+        body{ background:var(--bg); color:var(--text); font-family:ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; margin:0; }
+        .card{background:var(--card);border:1px solid var(--line)}
+        .btn{display:inline-flex;align-items:center;gap:.4rem;border-radius:.5rem;padding:.5rem .75rem;border:1px solid var(--line);background:var(--card)}
+        .btn-primary{background:var(--accent);border-color:var(--accent);color:white}
     </style>
 </head>
 <body>
-    <h1>Cache Clearing Helper</h1>
-    <p>This page helps clear browser cache and service worker cache for the Compliance Matrix app.</p>
-    
-    <button onclick="clearServiceWorkerCache()">Clear Service Worker Cache</button>
-    <button onclick="clearBrowserCache()">Clear Browser Cache</button>
-    <button onclick="reloadApp()">Reload App</button>
-    
-    <div id="status"></div>
-    
+    <div class="container mx-auto px-4 py-10">
+        <div class="card rounded-lg shadow p-6 max-w-lg mx-auto">
+            <h1 class="text-2xl font-bold mb-4">Cache Clearing Helper</h1>
+            <p class="mb-6">This page helps clear browser cache and service worker cache for the Compliance Matrix app.</p>
+
+            <div class="flex flex-wrap gap-3 mb-4">
+                <button onclick="clearServiceWorkerCache()" class="btn btn-primary">Clear Service Worker Cache</button>
+                <button onclick="clearBrowserCache()" class="btn btn-primary">Clear Browser Cache</button>
+                <button onclick="reloadApp()" class="btn">Reload App</button>
+            </div>
+
+            <div id="status" class="hidden"></div>
+        </div>
+    </div>
+
     <script>
         function showStatus(message, type = 'success') {
             const status = document.getElementById('status');
+            const baseClasses = 'mt-4 text-sm rounded border p-4 shadow';
+            const typeClasses = type === 'error'
+                ? 'bg-red-100 text-red-800'
+                : 'bg-green-100 text-green-800';
             status.textContent = message;
-            status.className = `status ${type}`;
+            status.className = `${baseClasses} ${typeClasses}`;
         }
         
         async function clearServiceWorkerCache() {


### PR DESCRIPTION
## Summary
- load the shared Maplewood stylesheet and duplicate the root theme variables for the cache helper
- restyle the cache helper layout with the Maplewood container and card components and use shared button styles
- update cache status messaging to use Tailwind utility classes instead of bespoke inline styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddfec02cac83278d4e8d445b9f3fb3