### PR TITLE
Add Wrangler configuration for static asset deployment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "maplewood-employee-compliance-tracker"
+compatibility_date = "2024-05-01"
+
+[assets]
+directory = "."


### PR DESCRIPTION
## Summary
- add a wrangler configuration file that names the worker and sets the compatibility date
- configure Wrangler to serve static assets from the repository root directory

## Testing
- not run (Wrangler deployment requires credentials)

------
https://chatgpt.com/codex/tasks/task_e_68deb7a1033c8327916c5fc8f084d215