### PR TITLE
Ensure fallback employee imports seed requirement requirement data

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -5,7 +5,7 @@ const clone = (value) => {
   return JSON.parse(JSON.stringify(value));
 };
 
-function generateId(){
+export function generateId(){
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
@@ -48,7 +48,7 @@ const prepareTemplateIndex = (templates = []) => {
   return { prepared, roleIndex };
 };
 
-const fetchTemplateIndex = async (db) => {
+export const fetchTemplateIndex = async (db) => {
   if (!db?.roleRequirementProfiles) {
     return { prepared: [], roleIndex: new Map() };
   }
@@ -61,7 +61,7 @@ const fetchTemplateIndex = async (db) => {
   }
 };
 
-const resolveTemplateForRole = (role, roleIndex) => {
+export const resolveTemplateForRole = (role, roleIndex) => {
   const key = normalizeRole(role);
   return roleIndex.get(key) || null;
 };
@@ -79,7 +79,7 @@ const templateExcludesRequirement = (template, requirementId) => {
   return excluded.includes(normalisedId);
 };
 
-const determineStatusForTemplate = (template, requirementId, fallback = 'NotCompleted') => {
+export const determineStatusForTemplate = (template, requirementId, fallback = 'NotCompleted') => {
   return templateExcludesRequirement(template, requirementId) ? 'NotRequired' : fallback;
 };
 

--- a/import-employees.js
+++ b/import-employees.js
@@ -250,6 +250,7 @@
 
     const timestamp = new Date().toISOString();
     const employees = [];
+    const newEmployeeIds = new Set();
 
     for (const r of rows){
       const nameVal = nameCol ? r[nameCol] : (r['Name'] ?? r['Employee'] ?? '');
@@ -268,7 +269,8 @@
         existingMatch = existingByComposite.get(compositeKey);
       }
 
-      const id = existingMatch ? existingMatch.id : (employeeIdValue || localGenerateId());
+      const isExisting = Boolean(existingMatch);
+      const id = isExisting ? existingMatch.id : (employeeIdValue || localGenerateId());
       const roleValue = roleCol ? (r[roleCol] ?? null) : null;
       const employmentTypeValue = etypeCol ? String(r[etypeCol] ?? '').toUpperCase() || null : null;
       const statusValue = String(statusCol ? (r[statusCol] ?? 'ACTIVE') : 'ACTIVE').toUpperCase();
@@ -302,6 +304,10 @@
 
       employees.push(employee);
 
+      if (!isExisting) {
+        newEmployeeIds.add(id);
+      }
+
       if (employeeIdKey && !existingByEmployeeId.has(employeeIdKey)) {
         existingByEmployeeId.set(employeeIdKey, employee);
       }
@@ -321,13 +327,53 @@
     });
 
     // Write to DB
-    await db.transaction('readwrite', db.employees, async () => {
+    const newlyCreatedEmployees = employees.filter(emp => newEmployeeIds.has(emp.id));
+
+    await db.transaction('readwrite', db.employees, db.employeeRequirements, db.requirements, db.roleRequirementProfiles, async () => {
       if (typeof db.employees.bulkPut === 'function') {
         await db.employees.bulkPut(employees);
       } else {
         for (const emp of employees) {
           await db.employees.put(emp);
         }
+      }
+
+      if (!newlyCreatedEmployees.length) {
+        return;
+      }
+
+      const requirements = await db.requirements.toArray();
+      if (!requirements.length) {
+        return;
+      }
+
+      const {
+        fetchTemplateIndex,
+        resolveTemplateForRole,
+        determineStatusForTemplate,
+        generateId
+      } = await import('./commands.js');
+      const { roleIndex } = await fetchTemplateIndex(db);
+
+      const employeeRequirementRows = [];
+      for (const employee of newlyCreatedEmployees) {
+        const template = resolveTemplateForRole(employee.role, roleIndex);
+        for (const requirement of requirements) {
+          employeeRequirementRows.push({
+            id: generateId(),
+            employeeId: employee.id,
+            requirementId: requirement.id,
+            status: determineStatusForTemplate(template, requirement.id),
+            completedOn: null,
+            expiresOn: null,
+            notes: null,
+            updatedAt: timestamp
+          });
+        }
+      }
+
+      if (employeeRequirementRows.length) {
+        await db.employeeRequirements.bulkAdd(employeeRequirementRows);
       }
     });
     return employees.length;


### PR DESCRIPTION
## Summary
- export the template helper utilities from `commands.js` so they can be reused by fallback imports
- update the fallback `importFromRows` flow to detect newly created employees and seed their requirement rows after saving

## Testing
- Manual verification attempted in browser (Playwright automation timing out due to external CDN dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68debdab6da08327ade2b86668fce40d