### PR TITLE
Fix import modal fallback close handling

### DIFF
--- a/import-employees.js
+++ b/import-employees.js
@@ -46,7 +46,7 @@
           toggleImportModal(false);
         };
 
-        modal.querySelectorAll('[\@click="showImportModal=false"]').forEach((el) => {
+        modal.querySelectorAll('[data-close-import-modal], [x-on\\:click="showImportModal=false"]').forEach((el) => {
           el.addEventListener('click', closeHandler);
           cleanupFns.push(() => el.removeEventListener('click', closeHandler));
         });

--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@
   <!-- Import Modal -->
   <div x-show="showImportModal" x-cloak class="fixed inset-0 z-50">
     <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-      <div @click="showImportModal=false" class="fixed inset-0 bg-black/40 z-40"></div>
+      <div @click="showImportModal=false" data-close-import-modal class="fixed inset-0 bg-black/40 z-40"></div>
       <span class="hidden sm:inline-block sm:align-middle sm:h-screen">&#8203;</span>
       <div class="relative z-50 inline-block align-bottom card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
         <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
@@ -916,7 +916,7 @@
         </div>
         <div class="bg-gray-50 dark:bg-gray-900 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
           <button @click="processImport" x-show="importData.length" class="w-full sm:w-auto px-4 py-2 btn btn-primary">Process Import</button>
-          <button @click="showImportModal=false" class="mt-3 sm:mt-0 sm:ml-3 w-full sm:w-auto px-4 py-2 btn">Cancel</button>
+          <button @click="showImportModal=false" data-close-import-modal class="mt-3 sm:mt-0 sm:ml-3 w-full sm:w-auto px-4 py-2 btn">Cancel</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update the import modal fallback close button selector to use valid CSS attributes
- tag the import modal overlay and cancel button with a dedicated data attribute for the fallback selector

## Testing
- npm run build *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dedfcf3b288327ac037fbe5934ff04