### PR TITLE
Refactor Dexie setup into shared database module

### DIFF
--- a/activity-log.js
+++ b/activity-log.js
@@ -1,4 +1,6 @@
 // ActivityLog – simple audit trail with undo capability.
+import { generateId } from './db.js';
+
 export default class ActivityLog {
   static async init(db) {
     // Ensure the table exists before opening.
@@ -30,7 +32,7 @@ export default class ActivityLog {
   // Record a completed command.
   async record({ actionType, actor, targets = [], metadata = {}, undoPayload }) {
     const entry = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       timestamp: Date.now(),
       actor,
       actionType,

--- a/calendar.html
+++ b/calendar.html
@@ -20,7 +20,7 @@
     .fc-scrollgrid, .fc-theme-standard td, .fc-theme-standard th{ border-color:var(--line); }
     .fc-event{ background:var(--accent); border-color:var(--accent); }
   </style>
-  <script defer src="calendar.js"></script>
+  <script type="module" src="calendar.js"></script>
 </head>
 <body>
   <div class="container mx-auto px-4 py-6">

--- a/calendar.js
+++ b/calendar.js
@@ -1,14 +1,14 @@
+import { createDatabase } from './db.js';
+
 document.addEventListener('DOMContentLoaded', async () => {
-  const db = new Dexie('ComplianceMatrixDB');
-  db.version(10).stores({
-    employees:'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
-    requirements:'id, name, defaultExpiryDays, color',
-    employeeRequirements:'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
-    settings:'id',
-    activityLog:'id,timestamp,actionType',
-    complianceSnapshots:'date',
-    roleRequirementProfiles:'id, name'
-  });
+  const db = createDatabase();
+
+  try {
+    await db.open();
+  } catch (error) {
+    console.error('Failed to open database for calendar', error);
+    return;
+  }
 
   try {
     const setting = await db.settings.get('app');

--- a/commands.js
+++ b/commands.js
@@ -1,19 +1,13 @@
 // Command implementations used by the activity log.
 
+import { generateId as sharedGenerateId } from './db.js';
+
 const clone = (value) => {
   if (value === undefined || value === null) return value;
   return JSON.parse(JSON.stringify(value));
 };
 
-export function generateId(){
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  if (typeof Dexie !== 'undefined' && typeof Dexie.uuid === 'function') {
-    return Dexie.uuid();
-  }
-  return Date.now().toString(36) + Math.random().toString(36).slice(2);
-}
+export const generateId = sharedGenerateId;
 
 const nowISO = () => new Date().toISOString();
 

--- a/db.js
+++ b/db.js
@@ -1,0 +1,105 @@
+const DB_NAME = 'ComplianceMatrixDB';
+
+export function getDexie() {
+  if (typeof window !== 'undefined' && window.Dexie) {
+    return window.Dexie;
+  }
+  if (typeof self !== 'undefined' && self.Dexie) {
+    return self.Dexie;
+  }
+  if (typeof globalThis !== 'undefined' && globalThis.Dexie) {
+    return globalThis.Dexie;
+  }
+  return null;
+}
+
+export function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const DexieRef = getDexie();
+  if (DexieRef && typeof DexieRef.uuid === 'function') {
+    return DexieRef.uuid();
+  }
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+function defineSchema(db) {
+  const v8Stores = {
+    employees: 'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
+    requirements: 'id, name, defaultExpiryDays, color',
+    employeeRequirements: 'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
+    settings: 'id',
+    activityLog: 'id,timestamp,actionType'
+  };
+
+  const v9Stores = {
+    ...v8Stores,
+    complianceSnapshots: 'date'
+  };
+
+  const v10Stores = {
+    ...v9Stores,
+    roleRequirementProfiles: 'id, name'
+  };
+
+  db.version(8).stores(v8Stores);
+  db.version(9).stores(v9Stores);
+  db.version(10).stores(v10Stores).upgrade(async tx => {
+    try {
+      const settingsTable = tx.table('settings');
+      const existingSetting = await settingsTable.get('roleRequirementProfiles');
+      if (!existingSetting) {
+        await settingsTable.put({ id: 'roleRequirementProfiles', value: [] });
+      }
+    } catch (error) {
+      console.warn('Failed to seed role requirement profile settings', error);
+    }
+  });
+
+  db.on('populate', tx => {
+    const now = new Date().toISOString();
+    const seed = (name, days = null, color = '#fef3c7') => ({
+      id: generateId(),
+      name,
+      defaultExpiryDays: days,
+      color,
+      createdAt: now,
+      updatedAt: now
+    });
+
+    tx.table('requirements').bulkAdd([
+      seed('Resume', null, '#e0e7ff'),
+      seed('References', null, '#f0f9ff'),
+      seed('First Aid', 1095, '#fef3c7'),
+      seed('CPR', 365, '#dcfce7'),
+      seed('FoodSafe', 1825, '#fce7f3'),
+      seed('Violence Prevention', 365, '#f3e8ff'),
+      seed('Background Check', 1095, '#fef2f2'),
+      seed('Drug Test', 365, '#fffbeb'),
+      seed('TB Test', 365, '#f0fdf4'),
+      seed('Immunization', 365, '#ecfdf5')
+    ]);
+
+    tx.table('settings').put({ id: 'app', darkMode: false });
+    tx.table('settings').put({ id: 'hasSeenTour', value: false });
+    tx.table('settings').put({ id: 'roleRequirementProfiles', value: [] });
+  });
+}
+
+export function createDatabase() {
+  const DexieRef = getDexie();
+  if (!DexieRef) {
+    throw new Error('Dexie is not available in the current environment');
+  }
+  const db = new DexieRef(DB_NAME);
+  defineSchema(db);
+  return db;
+}
+
+export async function openDatabase() {
+  const db = createDatabase();
+  await db.open();
+  return db;
+}
+

--- a/import-employees.js
+++ b/import-employees.js
@@ -1,3 +1,4 @@
+import { createDatabase, generateId } from './db.js';
 
 /**
  * Client-side importer for Employees.
@@ -78,80 +79,7 @@
   }
 
   function ensureDb(){
-    const db = new DexieRef('ComplianceMatrixDB');
-
-    const v8Stores = {
-      employees:'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
-      requirements:'id, name, defaultExpiryDays, color',
-      employeeRequirements:'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
-      settings:'id',
-      activityLog:'id,timestamp,actionType'
-    };
-
-    const v9Stores = {
-      ...v8Stores,
-      complianceSnapshots:'date'
-    };
-
-    const v10Stores = {
-      ...v9Stores,
-      roleRequirementProfiles:'id, name'
-    };
-
-    db.version(8).stores(v8Stores);
-    db.version(9).stores(v9Stores);
-    db.version(10).stores(v10Stores).upgrade(async tx => {
-      try {
-        const settingsTable = tx.table('settings');
-        const existingSetting = await settingsTable.get('roleRequirementProfiles');
-        if (!existingSetting) {
-          await settingsTable.put({ id:'roleRequirementProfiles', value:[] });
-        }
-      } catch (error) {
-        console.warn('Failed to seed role requirement profile settings', error);
-      }
-    });
-
-    db.on('populate', (tx) => {
-      const generateSeedId = () => {
-        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-          return crypto.randomUUID();
-        }
-        if (typeof DexieRef !== 'undefined' && typeof DexieRef.uuid === 'function') {
-          return DexieRef.uuid();
-        }
-        return Date.now().toString(36) + Math.random().toString(36).slice(2);
-      };
-
-      const now = new Date().toISOString();
-      const seed = (name, days=null, color='#fef3c7') => ({
-        id: generateSeedId(),
-        name,
-        defaultExpiryDays: days,
-        color,
-        createdAt: now,
-        updatedAt: now
-      });
-
-      tx.table('requirements').bulkAdd([
-        seed('Resume', null, '#e0e7ff'),
-        seed('References', null, '#f0f9ff'),
-        seed('First Aid', 1095, '#fef3c7'),
-        seed('CPR', 365, '#dcfce7'),
-        seed('FoodSafe', 1825, '#fce7f3'),
-        seed('Violence Prevention', 365, '#f3e8ff'),
-        seed('Background Check', 1095, '#fef2f2'),
-        seed('Drug Test', 365, '#fffbeb'),
-        seed('TB Test', 365, '#f0fdf4'),
-        seed('Immunization', 365, '#ecfdf5')
-      ]);
-
-      tx.table('settings').put({id:'app',darkMode:false});
-      tx.table('settings').put({id:'hasSeenTour', value:false});
-      tx.table('settings').put({id:'roleRequirementProfiles', value:[]});
-    });
-
-    return db;
+    return createDatabase();
   }
 
   function parseSeniority(val){
@@ -192,17 +120,7 @@
     return null;
   }
 
-  const localGenerateId = (typeof window !== 'undefined' && typeof window.generateId === 'function')
-    ? window.generateId
-    : () => {
-        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-          return crypto.randomUUID();
-        }
-        if (typeof DexieRef !== 'undefined' && typeof DexieRef.uuid === 'function') {
-          return DexieRef.uuid();
-        }
-        return Date.now().toString(36) + Math.random().toString(36).slice(2);
-      };
+  const localGenerateId = generateId;
 
   function normalizeEmployeeId(value){
     if (value == null) return '';

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@
 // Ensures bundler processes the entire dashboard logic.
 
 import './import-employees.js';
+import { createDatabase, generateId } from './db.js';
 
 window.addEventListener('DOMContentLoaded', function () {
   // Fallback for XLSX library loading
@@ -15,17 +16,6 @@ window.addEventListener('DOMContentLoaded', function () {
     document.head.appendChild(script);
   }
 });
-
-    function generateId(){
-      if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-        return crypto.randomUUID();
-      }
-      if (typeof Dexie !== 'undefined' && typeof Dexie.uuid === 'function') {
-        return Dexie.uuid();
-      }
-      return Date.now().toString(36) + Math.random().toString(36).slice(2);
-    }
-
     function activityTimeline(){
       return {
         entries: [],
@@ -195,60 +185,7 @@ window.addEventListener('DOMContentLoaded', function () {
           if (this.loadError || typeof window === 'undefined' || typeof window.Dexie === 'undefined') {
             return;
           }
-          this.db = new window.Dexie('ComplianceMatrixDB');
-          this.db.version(8).stores({
-            employees:'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
-            requirements:'id, name, defaultExpiryDays, color',
-            employeeRequirements:'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
-            settings:'id',
-            activityLog:'id,timestamp,actionType'
-          });
-          this.db.version(9).stores({
-            employees:'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
-            requirements:'id, name, defaultExpiryDays, color',
-            employeeRequirements:'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
-            settings:'id',
-            activityLog:'id,timestamp,actionType',
-            complianceSnapshots:'date'
-          });
-          this.db.version(10).stores({
-            employees:'id, lastName, firstName, role, employmentType, status, employeeId, seniorityHours',
-            requirements:'id, name, defaultExpiryDays, color',
-            employeeRequirements:'id, [employeeId+requirementId], status, completedOn, expiresOn, notes',
-            settings:'id',
-            activityLog:'id,timestamp,actionType',
-            complianceSnapshots:'date',
-            roleRequirementProfiles:'id, name'
-          }).upgrade(async tx => {
-            try{
-              const settingsTable = tx.table('settings');
-              const existingSetting = await settingsTable.get('roleRequirementProfiles');
-              if(!existingSetting){
-                await settingsTable.put({ id:'roleRequirementProfiles', value:[] });
-              }
-            }catch(error){
-              console.warn('Failed to seed role requirement profile settings', error);
-            }
-          });
-          this.db.on('populate', (tx) => {
-            const now = new Date().toISOString();
-            const seed = (name, days=null, color='#fef3c7')=>({id:generateId(),name,defaultExpiryDays:days,color,createdAt:now,updatedAt:now});
-            tx.table('requirements').bulkAdd([
-              seed('Resume', null, '#e0e7ff'), // Light blue
-              seed('References', null, '#f0f9ff'), // Light cyan
-              seed('First Aid', 1095, '#fef3c7'), // Light yellow
-              seed('CPR', 365, '#dcfce7'), // Light green
-              seed('FoodSafe', 1825, '#fce7f3'), // Light pink
-              seed('Violence Prevention', 365, '#f3e8ff'), // Light purple
-              seed('Background Check', 1095, '#fef2f2'), // Light red
-              seed('Drug Test', 365, '#fffbeb'), // Light amber
-              seed('TB Test', 365, '#f0fdf4'), // Light emerald
-              seed('Immunization', 365, '#ecfdf5') // Light green
-            ]);
-            tx.table('settings').put({id:'app',darkMode:false});
-            tx.table('settings').put({id:'hasSeenTour', value:false});
-            tx.table('settings').put({id:'roleRequirementProfiles', value:[]});
-          });
+          this.db = createDatabase();
         },
 
         async initActivityLog(){

--- a/sw.js
+++ b/sw.js
@@ -16,6 +16,7 @@ const PRECACHE_PATHS = [
   'icon-512.svg',
   'commands.js',
   'activity-log.js',
+  'db.js',
   'calendar.js',
   'onboarding.js'
 ,


### PR DESCRIPTION
## Summary
- add a shared db.js helper that centralises Dexie access, schema creation, ID helpers, and seeding
- update the dashboard, importer, and calendar scripts to consume the shared createDatabase/generateId helpers
- ensure the activity log uses the shared ID generator and pre-cache the new db.js while loading the calendar script as a module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedf1e5c5883278b3b19737d6d572c