### PR TITLE
Handle missing Papa library gracefully

### DIFF
--- a/main.js
+++ b/main.js
@@ -765,10 +765,23 @@ window.addEventListener('DOMContentLoaded', function () {
           }
           
           if (this.importType === 'csv') {
+            if (typeof Papa === 'undefined') {
+              this.importError = 'CSV parsing library is unavailable. Check your internet connection and try again.';
+              this.importLoading = false;
+              return;
+            }
             const text = await file.text();
             const lines = text.split(/\r?\n/);
             const body = this.stripTitleLines(lines);
-            const res = Papa.parse(body, { header:true, skipEmptyLines:true });
+            let res;
+            try {
+              res = Papa.parse(body, { header:true, skipEmptyLines:true });
+            } catch (parseError) {
+              console.error('Failed to parse CSV file', parseError);
+              this.importError = 'We could not read the CSV file. Ensure it is properly formatted and try again.';
+              this.importLoading = false;
+              return;
+            }
             this.importData = res.data; this.importHeaders = res.meta.fields || [];
             const trimmed = (res.meta.fields || []).map(h => h.trim());
             this.importData = res.data.map(row => {


### PR DESCRIPTION
## Summary
- display a clear error when the Papa Parse CDN fails to load before importing CSV files
- guard the CSV import flow by catching parsing errors so malformed data shows a readable message

## Testing
- Manual testing blocked (Playwright browser launch timed out in container)


------
https://chatgpt.com/codex/tasks/task_e_68deeabd76a88327af2639a3e9bc989a