### PR TITLE
Refine dashboard header layout and button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,26 @@
     body{ background:var(--bg); color:var(--text); }
     [x-cloak]{display:none!important}
     .card{background:var(--card);border:1px solid var(--line)}
-    .btn{display:inline-flex;align-items:center;gap:.4rem;border-radius:.5rem;padding:.5rem .75rem;border:1px solid var(--line);background:var(--card)}
-    .btn-primary{background:var(--accent);border-color:var(--accent);color:white}
+    .btn{display:inline-flex;align-items:center;justify-content:center;gap:.45rem;border-radius:.75rem;padding:.5rem .85rem;border:1px solid var(--line);background:var(--card);font-weight:600;transition:background .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease}
+    .btn:hover,.btn:focus-visible{box-shadow:0 4px 12px rgba(15,23,42,0.12);outline:none}
+    .btn:focus-visible{border-color:var(--accent)}
+    .btn-accent{background:var(--accent);border-color:var(--accent);color:#fff}
+    .btn-accent:hover,.btn-accent:focus-visible{background:rgba(37,99,235,0.92);border-color:rgba(37,99,235,0.92)}
+    .dark .btn-accent:hover,.dark .btn-accent:focus-visible{background:rgba(96,165,250,0.85);border-color:rgba(96,165,250,0.85)}
+    .btn-danger{background:var(--danger);border-color:var(--danger);color:#fff}
+    .btn-danger:hover,.btn-danger:focus-visible{background:rgba(239,68,68,0.9);border-color:rgba(239,68,68,0.9)}
+    .dark .btn-danger:hover,.dark .btn-danger:focus-visible{background:rgba(248,113,113,0.9);border-color:rgba(248,113,113,0.9)}
+    .btn-ghost{background:transparent;color:var(--text)}
+    .btn-ghost:hover,.btn-ghost:focus-visible{background:rgba(17,24,39,0.06);border-color:var(--line)}
+    .dark .btn-ghost:hover,.dark .btn-ghost:focus-visible{background:rgba(243,244,246,0.08)}
+    .btn-icon{padding:.5rem;border-radius:9999px;width:2.5rem;height:2.5rem}
+    .btn-icon i{margin:0}
+    .dashboard-header{display:flex;flex-direction:column;gap:1rem}
+    .dashboard-header__masthead{display:flex;flex-direction:column;gap:1rem}
+    .command-toolbar{display:flex;flex-direction:column;width:100%;gap:.75rem}
+    .command-toolbar__group{display:flex;flex-wrap:wrap;align-items:center;gap:.5rem}
+    .command-toolbar__group--primary{padding-bottom:.25rem;border-bottom:1px solid var(--line)}
+    .command-toolbar__group--secondary{padding-top:.25rem}
     .sticky-col{position:sticky;left:0;z-index:10;background:var(--card);min-width:14rem}
     .checkbox{appearance:none;width:1.25rem;height:1.25rem;border:2px solid var(--line);border-radius:.25rem;cursor:pointer;position:relative;background:var(--card);transition:all 0.2s ease;display:inline-block}
     .checkbox:hover{transform:scale(1.1);box-shadow:0 2px 4px rgba(0,0,0,0.1)}
@@ -68,6 +86,14 @@
     .dark .search-result-icon{background:rgba(96,165,250,0.15)}
     .search-result-type{display:inline-block;font-size:.65rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.15rem;color:var(--muted)}
     .search-focus-ring{outline:2px solid var(--accent);outline-offset:2px;animation:search-focus-pulse 1.6s ease-out}
+    @media (min-width:768px){
+      .dashboard-header{flex-direction:column;gap:1.5rem}
+      .dashboard-header__masthead{flex-direction:row;align-items:center;justify-content:space-between}
+      .command-toolbar{flex-direction:row;align-items:center;justify-content:space-between;gap:1.5rem}
+      .command-toolbar__group{flex-wrap:nowrap;gap:.75rem}
+      .command-toolbar__group--primary{flex:1;border-bottom:none;padding-bottom:0}
+      .command-toolbar__group--secondary{flex:1;justify-content:flex-end;padding-top:0}
+    }
     @keyframes search-focus-pulse{0%{box-shadow:0 0 0 0 rgba(37,99,235,0.55);}50%{box-shadow:0 0 0 6px rgba(37,99,235,0.25);}100%{box-shadow:0 0 0 0 rgba(37,99,235,0);}}
   </style>
 </head>
@@ -91,88 +117,114 @@
   </div>
 
   <div id="dashboard-app" class="container mx-auto px-4 py-6" x-show="!loadError">
-    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
-      <!-- Mobile stacks branding, search, and actions for clarity -->
-      <!-- Anchors Maplewood branding to the primary view -->
-      <div class="flex items-center gap-3">
-        <img src="icon-192.svg" alt="Maplewood icon" class="w-10 h-10 rounded-lg shadow-sm">
-        <h1 class="text-2xl font-bold">Maplewood Compliance Matrix</h1>
-      </div>
-      <div class="search-float w-full md:w-auto">
-        <div class="relative w-full md:w-72 md:max-w-md" @keydown.escape.window="dismissSearchResults()">
-          <input
-            id="global-search"
-            aria-label="Search employees and requirements"
-            x-model="globalSearch"
-            @input="performGlobalSearch(globalSearch)"
-            type="text"
-            placeholder="Search..."
-            class="w-full pl-3 pr-8 py-1 border rounded bg-white dark:bg-gray-800"
-            style="border-color:var(--line);"
-        />
-        <!-- Added for accessibility: ensure global search field has an accessible label -->
-        <button
-          x-show="globalSearch"
-          @click="clearGlobalSearch"
-          class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
-        >
-          <i data-feather="x" class="w-4 h-4"></i>
-        </button>
-
-        <div
-          x-show="searchResults.length"
-          x-transition
-          class="search-results-panel"
-          @click.outside="dismissSearchResults()"
-        >
-          <template x-for="result in searchResults" :key="`${result.item.id}-${result.item.type}`">
-            <button
-              type="button"
-              class="search-result-item"
-              @click="focusSearchResult(result)"
-            >
-              <span class="search-result-icon">
-                <i
-                  :data-feather="result.item.type === 'employee' ? 'user' : 'target'"
-                  class="w-4 h-4"
-                ></i>
-              </span>
-              <span class="min-w-0 flex-1">
-                <span class="search-result-type" x-text="result.item.type === 'employee' ? 'Employee' : 'Requirement'"></span>
-                <span class="block text-sm font-semibold" x-html="highlightText(result.item.label)"></span>
-                <template x-if="result.item.type === 'employee'">
-                  <span class="block text-xs" style="color:var(--muted)">
-                    <span x-show="result.item.meta?.role" x-html="highlightText(result.item.meta?.role)"></span>
-                    <template x-if="result.item.meta?.role && result.item.meta?.employeeId">
-                      <span class="mx-1">•</span>
-                    </template>
-                    <span x-show="result.item.meta?.employeeId" x-html="highlightText(result.item.meta?.employeeId)"></span>
-                  </span>
-                </template>
-              </span>
-            </button>
-          </template>
+    <div class="dashboard-header mb-4">
+      <div class="dashboard-header__masthead">
+        <div class="flex items-center gap-3">
+          <img src="icon-192.svg" alt="Maplewood icon" class="w-10 h-10 rounded-lg shadow-sm">
+          <h1 class="text-2xl font-bold">Maplewood Compliance Matrix</h1>
         </div>
-      </div>
-    </div>
+        <div class="search-float w-full md:w-auto">
+          <div class="relative w-full md:w-72 md:max-w-md" @keydown.escape.window="dismissSearchResults()">
+            <input
+              id="global-search"
+              aria-label="Search employees and requirements"
+              x-model="globalSearch"
+              @input="performGlobalSearch(globalSearch)"
+              type="text"
+              placeholder="Search..."
+              class="w-full pl-3 pr-8 py-1 border rounded bg-white dark:bg-gray-800"
+              style="border-color:var(--line);"
+            />
+            <!-- Added for accessibility: ensure global search field has an accessible label -->
+            <button
+              x-show="globalSearch"
+              @click="clearGlobalSearch"
+              class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+            >
+              <i data-feather="x" class="w-4 h-4"></i>
+            </button>
 
-      <div class="flex flex-wrap gap-2 gap-y-2 sm:flex-nowrap"><!-- Wrap intentionally enabled on small screens -->
-        <button id="import-btn" @click="showImportModal = true" class="btn"><i data-feather="upload" class="w-4 h-4"></i><span>Import</span></button>
-        <div class="relative">
-          <button id="export-btn" @click="showExportDropdown = !showExportDropdown" class="btn"><i data-feather="download" class="w-4 h-4"></i><span>Export</span></button>
-          <div x-show="showExportDropdown" @click.away="showExportDropdown = false" class="absolute right-0 mt-2 w-32 border rounded shadow bg-white dark:bg-gray-800 z-10">
-            <button @click="exportData('json'); showExportDropdown=false" class="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">JSON</button>
-            <button @click="exportData('csv'); showExportDropdown=false" class="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">CSV</button>
-            <button @click="exportData('xlsx'); showExportDropdown=false" class="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">Excel</button>
+            <div
+              x-show="searchResults.length"
+              x-transition
+              class="search-results-panel"
+              @click.outside="dismissSearchResults()"
+            >
+              <template x-for="result in searchResults" :key="`${result.item.id}-${result.item.type}`">
+                <button
+                  type="button"
+                  class="search-result-item"
+                  @click="focusSearchResult(result)"
+                >
+                  <span class="search-result-icon">
+                    <i
+                      :data-feather="result.item.type === 'employee' ? 'user' : 'target'"
+                      class="w-4 h-4"
+                    ></i>
+                  </span>
+                  <span class="min-w-0 flex-1">
+                    <span class="search-result-type" x-text="result.item.type === 'employee' ? 'Employee' : 'Requirement'"></span>
+                    <span class="block text-sm font-semibold" x-html="highlightText(result.item.label)"></span>
+                    <template x-if="result.item.type === 'employee'">
+                      <span class="block text-xs" style="color:var(--muted)">
+                        <span x-show="result.item.meta?.role" x-html="highlightText(result.item.meta?.role)"></span>
+                        <template x-if="result.item.meta?.role && result.item.meta?.employeeId">
+                          <span class="mx-1">•</span>
+                        </template>
+                        <span x-show="result.item.meta?.employeeId" x-html="highlightText(result.item.meta?.employeeId)"></span>
+                      </span>
+                    </template>
+                  </span>
+                </button>
+              </template>
+            </div>
           </div>
         </div>
-        <button @click="clearAllData" class="btn"><i data-feather="trash-2" class="w-4 h-4"></i><span>Clear</span></button>
-        <button id="activity-log-btn" @click="openActivityLog()" class="btn"><i data-feather="list" class="w-4 h-4"></i><span>Activity Log</span></button>
-        <button id="calendar-btn" @click="openCalendar()" class="btn"><i data-feather="calendar" class="w-4 h-4"></i><span>Calendar</span></button>
-        <button id="settings-btn" @click="openSettingsModal()" class="btn"><i data-feather="settings" class="w-4 h-4"></i><span>Settings</span></button>
-        <button id="help-btn" @click="beginTour()" class="btn" :class="{'help-highlight': highlightHelpButton}"><i data-feather="help-circle" class="w-4 h-4"></i><span>Help</span></button>
-        <button @click="toggleDarkMode()" class="btn" aria-label="Toggle dark mode"><i :data-feather="darkMode ? 'sun' : 'moon'" class="w-4 h-4"></i></button>
       </div>
+      <nav class="command-toolbar" aria-label="Dashboard actions">
+        <div class="command-toolbar__group command-toolbar__group--primary" role="group" aria-label="Primary actions">
+          <button id="import-btn" @click="showImportModal = true" class="btn btn-accent">
+            <i data-feather="upload" class="w-4 h-4"></i>
+            <span>Import</span>
+          </button>
+          <div class="relative">
+            <button id="export-btn" @click="showExportDropdown = !showExportDropdown" class="btn btn-accent">
+              <i data-feather="download" class="w-4 h-4"></i>
+              <span>Export</span>
+            </button>
+            <div x-show="showExportDropdown" @click.away="showExportDropdown = false" class="absolute right-0 mt-2 w-32 border rounded shadow bg-white dark:bg-gray-800 z-10">
+              <button @click="exportData('json'); showExportDropdown=false" class="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">JSON</button>
+              <button @click="exportData('csv'); showExportDropdown=false" class="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">CSV</button>
+              <button @click="exportData('xlsx'); showExportDropdown=false" class="block w-full text-left px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700">Excel</button>
+            </div>
+          </div>
+          <button @click="clearAllData" class="btn btn-danger">
+            <i data-feather="trash-2" class="w-4 h-4"></i>
+            <span>Clear</span>
+          </button>
+        </div>
+        <div class="command-toolbar__group command-toolbar__group--secondary" role="group" aria-label="Secondary actions">
+          <button id="activity-log-btn" @click="openActivityLog()" class="btn btn-ghost">
+            <i data-feather="list" class="w-4 h-4"></i>
+            <span>Activity Log</span>
+          </button>
+          <button id="calendar-btn" @click="openCalendar()" class="btn btn-ghost">
+            <i data-feather="calendar" class="w-4 h-4"></i>
+            <span>Calendar</span>
+          </button>
+          <button id="settings-btn" @click="openSettingsModal()" class="btn btn-ghost">
+            <i data-feather="settings" class="w-4 h-4"></i>
+            <span>Settings</span>
+          </button>
+          <button id="help-btn" @click="beginTour()" class="btn btn-ghost" :class="{'help-highlight': highlightHelpButton}">
+            <i data-feather="help-circle" class="w-4 h-4"></i>
+            <span>Help</span>
+          </button>
+          <button @click="toggleDarkMode()" class="btn btn-ghost btn-icon" aria-label="Toggle dark mode">
+            <i :data-feather="darkMode ? 'sun' : 'moon'" class="w-4 h-4"></i>
+          </button>
+        </div>
+      </nav>
     </div>
 
     <div class="mb-3 text-sm" :style="'color:var(--muted)'">


### PR DESCRIPTION
## Summary
- Group the dashboard branding and search within a new `.dashboard-header` masthead and command toolbar
- Apply accent, danger, ghost, and icon button variants to the primary and secondary action groups
- Extend the inline styles with responsive layout handling and focus/hover states for the updated toolbar

## Testing
- Not run (manual UI verification required)


------
https://chatgpt.com/codex/tasks/task_e_68def92dd4a48327969cf8f770c99537