### PR TITLE
Add striped styling for employee table

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,14 @@
     .command-toolbar__group--primary{padding-bottom:.25rem;border-bottom:1px solid var(--line)}
     .command-toolbar__group--secondary{padding-top:.25rem}
     .sticky-col{position:sticky;left:0;z-index:10;background:var(--card);min-width:14rem}
+    .table-striped th,.table-striped td{vertical-align:middle}
+    .table-striped tbody tr:nth-child(odd){background-color:var(--card)}
+    .table-striped tbody tr:nth-child(even){background-color:rgba(17,24,39,0.03)}
+    .table-striped tbody tr{transition:background-color .2s ease}
+    .table-striped tbody tr .sticky-col{background-color:inherit}
+    .dark .table-striped tbody tr:nth-child(odd){background-color:var(--card)}
+    .dark .table-striped tbody tr:nth-child(even){background-color:rgba(255,255,255,0.04)}
+    .dark .table-striped tbody tr .sticky-col{background-color:inherit}
     .checkbox{appearance:none;width:1.25rem;height:1.25rem;border:2px solid var(--line);border-radius:.25rem;cursor:pointer;position:relative;background:var(--card);transition:all 0.2s ease;display:inline-block}
     .checkbox:hover{transform:scale(1.1);box-shadow:0 2px 4px rgba(0,0,0,0.1)}
     .checkbox:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
@@ -51,7 +59,9 @@
     .checkbox.completed::after{content:"";position:absolute;left:50%;top:50%;transform:translate(-50%,-60%) rotate(-45deg);width:.75rem;height:.4rem;border-left:2px solid #fff;border-bottom:2px solid #fff}
     .virtual-scroll{overflow-y:auto;max-height:calc(100vh - 260px)}
     .status-badge{transition:all 0.2s ease}
-    .badge{display:inline-flex;align-items:center;padding:.125rem .5rem;border-radius:.25rem;font-size:.75rem;font-weight:600;color:var(--badge-text);border:none;cursor:pointer}
+    .badge{display:inline-flex;align-items:center;padding:.125rem .5rem;border-radius:.25rem;font-size:.75rem;font-weight:600;color:var(--badge-text);border:none;cursor:pointer;transition:box-shadow .2s ease,transform .2s ease}
+    .badge:hover,.badge:focus-visible{transform:translateY(-1px);box-shadow:0 0 0 3px rgba(37,99,235,0.18);outline:none}
+    .dark .badge:hover,.dark .badge:focus-visible{box-shadow:0 0 0 3px rgba(96,165,250,0.25)}
     .badge--compliant{background:var(--success)}
     .badge--expiring{background:var(--warn)}
     .badge--overdue{background:var(--danger)}
@@ -233,7 +243,7 @@
 
     <div class="card rounded-lg shadow overflow-hidden">
       <div class="overflow-x-auto">
-        <table id="employee-table" x-ref="employeeTable" class="min-w-full divide-y" style="border-color:var(--line)">
+        <table id="employee-table" x-ref="employeeTable" class="table-striped min-w-full divide-y" style="border-color:var(--line)">
           <thead class="bg-gray-50 dark:bg-gray-900">
             <tr>
               <th @click="sortEmployees('firstName')" class="sticky-col px-6 py-3 text-left text-xs font-medium uppercase tracking-wider cursor-pointer" style="color:var(--muted)">


### PR DESCRIPTION
## Summary
- define inline `.table-striped` rules with light and dark backgrounds plus vertical centering
- apply the new striped styling to the employee table without affecting sticky columns or hover behavior
- refine compliance badge hover and focus feedback to keep tooltips and click targets reliable

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68defdc570bc8327a7fa9d83cec83091