### PR TITLE
Bundle AlpineJS locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -1055,14 +1055,6 @@
   </div>
 
   <script type="module" src="/main.js"></script>
-  <script
-    src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.0/dist/cdn.min.js"
-    defer
-    onload="window.Alpine && window.Alpine.start()"
-  ></script>
-
-
-
 
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 // Consolidated application initialization script extracted from index.html
 // Ensures bundler processes the entire dashboard logic.
 
+import Alpine from 'alpinejs';
 import Papa from 'papaparse';
 import * as XLSX from 'xlsx';
 import Chart from 'chart.js/auto';
@@ -12,6 +13,8 @@ import './styles.css';
 import './import-employees.js';
 import './onboarding.js';
 import { createDatabase, generateId } from './db.js';
+
+window.Alpine = Alpine;
 
 const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev';
     function activityTimeline(){
@@ -71,9 +74,7 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
       };
     }
 
-    document.addEventListener('alpine:init', () => {
-      Alpine.data('activityTimeline', activityTimeline);
-      Alpine.data('app', () => ({
+    const app = () => ({
         loadError:'',
         darkMode:false, showImportModal:false, showExportDropdown:false,
         showSettingsModal:false, settingsSortable:null,
@@ -2180,8 +2181,11 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
           this.showBulkActionsModal = false;
           await this.loadData();
         }
-      }));
-    });
+      });
+
+    Alpine.data('activityTimeline', activityTimeline);
+    Alpine.data('app', app);
+
     function showFallback() {
       document.body?.removeAttribute('x-cloak');
 
@@ -2234,3 +2238,5 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
   window.addEventListener('DOMContentLoaded', ()=> {
     if (window.__initImportUI) window.__initImportUI();
   });
+
+  Alpine.start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "maplewood-employee-compliance-tracker",
       "version": "1.0.0",
       "dependencies": {
+        "alpinejs": "^3.13.0",
         "chart.js": "^4.4.1",
         "dexie": "^3.2.4",
         "feather-icons": "^4.29.1",
@@ -2415,6 +2416,21 @@
         "vite": "^5.0.0"
       }
     },
+    "node_modules/@vue/reactivity": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.1.5"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2436,6 +2452,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/alpinejs": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.0.tgz",
+      "integrity": "sha512-lpokA5okCF1BKh10LG8YjqhfpxyHBk4gE7boIgVHltJzYoM7O9nK3M7VlntLEJGsVmu7U/RzUWajmHREGT38Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.1.1"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "feather-icons": "^4.29.1",
     "fullcalendar": "^6.1.8",
     "fuse.js": "^6.6.2",
+    "alpinejs": "^3.13.0",
     "papaparse": "^5.4.1",
     "regenerator-runtime": "^0.14.1",
     "sortablejs": "^1.15.0",


### PR DESCRIPTION
## Summary
- add alpinejs as an npm dependency so it can be imported in the bundled dashboard
- register the app and activity timeline stores with Alpine in main.js and start it manually
- remove the CDN alpine script so the module controls initialization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1a2e5654832799326f06dc481498