### PR TITLE
Use Promise.all for loadData queries

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,9 +402,14 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
 
         async loadData(){
           if (this.loadError || !this.db) return;
-          this.employees = await this.db.employees.toArray();
-          this.requirements = await this.db.requirements.toArray();
-          this.employeeRequirements = await this.db.employeeRequirements.toArray();
+          const [employees, requirements, employeeRequirements] = await Promise.all([
+            this.db.employees.toArray(),
+            this.db.requirements.toArray(),
+            this.db.employeeRequirements.toArray()
+          ]);
+          this.employees = employees;
+          this.requirements = requirements;
+          this.employeeRequirements = employeeRequirements;
           this.erMap = new Map();
           for (const er of this.employeeRequirements){
             if(!this.erMap.has(er.employeeId)) this.erMap.set(er.employeeId,new Map());


### PR DESCRIPTION
## Summary
- fetch employees, requirements, and employee requirement records concurrently in loadData
- continue reusing the retrieved arrays for the existing mapping and refresh logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff55ddf388327b456b00781073c9d