### PR TITLE
Update deployment docs for Vite build process

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,16 +6,21 @@ The application is a static site and can be hosted on any web server.
 
 1. Fork the repository.
 2. Connect the fork to Netlify.
-3. Deploy from the `main` or `work` branch with the publish directory set to the repository root.
+3. Configure the build command to `npm run build` and the publish directory to `dist`.
 
 ## Other Hosts
 
-Serve the contents of the repository with any static file server or CDN.
+1. Install dependencies with `npm install`.
+2. Generate a production build with `npm run build`.
+3. Deploy the contents of the `dist` directory to your static host or CDN.
 
-For local testing run:
+For local development, run:
 
 ```bash
-npx serve .
+npm install
+npm run dev
 ```
 
-and open the provided URL.
+and open the provided URL from the Vite dev server.
+
+> **Note:** The source code uses bare module imports. Serve it through the Vite dev server (`npm run dev`) or deploy the compiled `dist` artifacts; otherwise dependencies such as Dexie, XLSX, and Alpine.js will fail to load when served directly from the repository root.


### PR DESCRIPTION
## Summary
- update Netlify instructions to run the Vite build and publish the dist folder
- document build steps for other hosts and local development
- explain the need to serve the app via Vite or built assets due to bare module imports

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68dff7f6f3208327bcb0e1f07873515b