### PR TITLE
Handle dynamic Dexie loading

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -6,9 +6,10 @@ import { createDatabase } from './db.js';
 import './styles.css';
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const db = createDatabase();
+  let db;
 
   try {
+    db = await createDatabase();
     await db.open();
   } catch (error) {
     console.error('Failed to open database for calendar', error);

--- a/db.js
+++ b/db.js
@@ -2,8 +2,153 @@ import Dexie from 'dexie';
 
 const DB_NAME = 'ComplianceMatrixDB';
 
+let DexieRef = Dexie ?? null;
+let dexieLoaderPromise = null;
+let cdnLoaderPromise = null;
+
+function setDexie(module) {
+  if (!module) {
+    DexieRef = null;
+    return DexieRef;
+  }
+
+  DexieRef = module?.default ?? module;
+  return DexieRef;
+}
+
+setDexie(Dexie);
+
 export function getDexie() {
-  return Dexie;
+  return DexieRef;
+}
+
+async function loadDexieFromDynamicImport() {
+  const module = await import('dexie');
+  return setDexie(module);
+}
+
+async function loadDexieFromCdn() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+
+  if (window.Dexie) {
+    return setDexie(window.Dexie);
+  }
+
+  if (!cdnLoaderPromise) {
+    cdnLoaderPromise = new Promise((resolve, reject) => {
+      const existing = document.querySelector('script[data-dexie-cdn]');
+
+      if (existing) {
+        const handleLoad = () => {
+          existing.removeEventListener('load', handleLoad);
+          existing.removeEventListener('error', handleError);
+          if (window.Dexie) {
+            resolve(setDexie(window.Dexie));
+          } else {
+            reject(new Error('Dexie CDN script loaded without exposing Dexie'));
+          }
+        };
+
+        const handleError = event => {
+          existing.removeEventListener('load', handleLoad);
+          existing.removeEventListener('error', handleError);
+          reject(event?.error || new Error('Failed to load Dexie from CDN'));
+        };
+
+        existing.addEventListener('load', handleLoad, { once: true });
+        existing.addEventListener('error', handleError, { once: true });
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/dexie@3.2.4/dist/dexie.min.js';
+      script.async = true;
+      script.dataset.dexieCdn = 'true';
+
+      const handleLoad = () => {
+        script.removeEventListener('load', handleLoad);
+        script.removeEventListener('error', handleError);
+        if (window.Dexie) {
+          resolve(setDexie(window.Dexie));
+        } else {
+          reject(new Error('Dexie CDN script loaded without exposing Dexie'));
+        }
+      };
+
+      const handleError = event => {
+        script.removeEventListener('load', handleLoad);
+        script.removeEventListener('error', handleError);
+        reject(event?.error || new Error('Failed to load Dexie from CDN'));
+      };
+
+      script.addEventListener('load', handleLoad);
+      script.addEventListener('error', handleError);
+      document.head.appendChild(script);
+    }).finally(() => {
+      if (!getDexie()) {
+        cdnLoaderPromise = null;
+      }
+    });
+  }
+
+  return cdnLoaderPromise;
+}
+
+async function loadDexie() {
+  if (getDexie()) {
+    return getDexie();
+  }
+
+  if (!dexieLoaderPromise) {
+    dexieLoaderPromise = (async () => {
+      try {
+        return await loadDexieFromDynamicImport();
+      } catch (dynamicError) {
+        if (typeof window === 'undefined') {
+          throw dynamicError;
+        }
+
+        try {
+          const cdnDexie = await loadDexieFromCdn();
+          if (cdnDexie) {
+            return cdnDexie;
+          }
+        } catch (cdnError) {
+          const aggregate = new Error('Dexie failed to load');
+          aggregate.cause = { dynamicError, cdnError };
+          throw aggregate;
+        }
+
+        throw dynamicError;
+      }
+    })().finally(() => {
+      if (!getDexie()) {
+        dexieLoaderPromise = null;
+      }
+    });
+  }
+
+  return dexieLoaderPromise;
+}
+
+export async function ensureDexieLoaded() {
+  if (getDexie()) {
+    return getDexie();
+  }
+
+  try {
+    const DexieInstance = await loadDexie();
+    if (!DexieInstance) {
+      throw new Error('Dexie resolved to a falsy value');
+    }
+    return DexieInstance;
+  } catch (error) {
+    const loadError = new Error('Dexie failed to load');
+    loadError.cause = error;
+    throw loadError;
+  }
 }
 
 export function generateId() {
@@ -80,15 +225,23 @@ function defineSchema(db) {
   });
 }
 
-export function createDatabase() {
-  const DexieRef = getDexie();
-  const db = new DexieRef(DB_NAME);
+export async function createDatabase() {
+  let DexieInstance = getDexie();
+  if (!DexieInstance) {
+    DexieInstance = await ensureDexieLoaded();
+  }
+
+  if (!DexieInstance) {
+    throw new Error('Dexie failed to load');
+  }
+
+  const db = new DexieInstance(DB_NAME);
   defineSchema(db);
   return db;
 }
 
 export async function openDatabase() {
-  const db = createDatabase();
+  const db = await createDatabase();
   await db.open();
   return db;
 }

--- a/import-employees.js
+++ b/import-employees.js
@@ -1,6 +1,6 @@
 import Papa from 'papaparse';
 
-import { createDatabase, generateId } from './db.js';
+import { createDatabase, ensureDexieLoaded, generateId } from './db.js';
 
 /**
  * Client-side importer for Employees.
@@ -75,8 +75,9 @@ import { createDatabase, generateId } from './db.js';
     return false;
   }
 
-  function ensureDb(){
-    return createDatabase();
+  async function ensureDb(){
+    await ensureDexieLoaded();
+    return await createDatabase();
   }
 
   function parseSeniority(val){
@@ -142,7 +143,7 @@ import { createDatabase, generateId } from './db.js';
     const wingCol      = detectColumn(header, ['wing','unit','department','dept']);
     const startCol     = detectColumn(header, ['start date','hire date','seniority date']);
 
-    const db = ensureDb();
+    const db = await ensureDb();
     await db.open();
 
     const existingEmployees = await db.employees.toArray();

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ import feather from 'feather-icons';
 import './styles.css';
 import './import-employees.js';
 import './onboarding.js';
-import { createDatabase, generateId } from './db.js';
+import { createDatabase, ensureDexieLoaded, generateId } from './db.js';
 
 window.Alpine = Alpine;
 
@@ -308,7 +308,7 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
         },
 
         async init(){
-          this.initDB();
+          await this.initDB();
           if (this.loadError || !this.db) {
             this.$nextTick(() => this.$root?.removeAttribute('x-cloak'));
             return;
@@ -355,15 +355,17 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
           }
         },
 
-        initDB(){
+        async initDB(){
           if (this.loadError || typeof window === 'undefined') {
             return;
           }
           try {
-            this.db = createDatabase();
+            await ensureDexieLoaded();
+            this.db = await createDatabase();
           } catch (error) {
             console.error('Failed to initialize Dexie database', error);
             this.loadError = 'The offline database library (Dexie.js) did not load. Data cannot be displayed without it.';
+            this.db = null;
           }
         },
 
@@ -395,7 +397,7 @@ const BUILD_HASH = typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev
             return;
           }
           await this.db.delete();
-          this.initDB();
+          await this.initDB();
           await this.initActivityLog();
           await this.loadData();
           this.notify('All data cleared');


### PR DESCRIPTION
## Summary
- add a Dexie loader that retries with a CDN fallback before instantiating the database
- update Alpine init and the employee importer to await Dexie so load errors surface without crashing
- adjust the calendar bootstrapper to await asynchronous database creation

## Testing
- npm test -- --runTestsByPath autoMapColumns.test.js *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68dff7f11cec832786cb5505244526fe