### PR TITLE
Update static deployment configs to build Vite assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  command = ""
-  publish = "."
+  command = "npm install && npm run build"
+  publish = "dist"
 
 [[headers]]
   for = "/*"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,8 @@
 name = "maplewood-employee-compliance-tracker"
 compatibility_date = "2024-05-01"
 
+[build]
+command = "npm install && npm run build"
+
 [assets]
-directory = "."
+directory = "dist"


### PR DESCRIPTION
## Summary
- configure the Netlify build to install dependencies, run the Vite build, and publish the generated dist output
- add the same build command to the Cloudflare Wrangler configuration and switch its asset directory to dist

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dffac0f8bc8327afecdc19254fc942