### PR TITLE
Ensure select-all checkbox stays in sync with filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
               <div class="filters-grid">
                 <label class="filter-field" aria-label="Filter by role">
                 <span class="filter-label">Role</span>
-                <select multiple size="4" class="input" x-model="filters.roles" @change="applyFilters">
+                <select multiple size="4" class="input" x-model="filters.roles" @change="onFiltersChanged">
                   <template x-if="!roleOptions.length">
                     <option disabled value="">No roles available</option>
                   </template>
@@ -233,7 +233,7 @@
               </label>
               <label class="filter-field" aria-label="Filter by employee status">
                 <span class="filter-label">Status</span>
-                <select class="input" x-model="filters.status" @change="applyFilters">
+                <select class="input" x-model="filters.status" @change="onFiltersChanged">
                   <template x-for="option in statusOptions" :key="option.value">
                     <option :value="option.value" x-text="option.label"></option>
                   </template>
@@ -241,7 +241,7 @@
               </label>
               <label class="filter-field" aria-label="Filter by compliance percentage">
                 <span class="filter-label">Compliance %</span>
-                <select class="input" x-model="filters.compliance" @change="applyFilters">
+                <select class="input" x-model="filters.compliance" @change="onFiltersChanged">
                   <template x-for="option in complianceOptions" :key="option.value">
                     <option :value="option.value" x-text="option.label"></option>
                   </template>
@@ -250,13 +250,13 @@
               <label class="filter-field" aria-label="Filter by expiration window">
                 <span class="filter-label">Expiring soon</span>
                 <div class="toggle-row">
-                  <input id="expiring-toggle" type="checkbox" class="toggle" x-model="filters.expiringSoon" @change="applyFilters" />
+                  <input id="expiring-toggle" type="checkbox" class="toggle" x-model="filters.expiringSoon" @change="onFiltersChanged" />
                   <label class="toggle-label" for="expiring-toggle">Within 30 days</label>
                 </div>
               </label>
               <label class="filter-field filter-wide" aria-label="Search employees">
                 <span class="filter-label">Search</span>
-                <input type="search" class="input" placeholder="Search by name" x-model="filters.search" @input.debounce.200ms="applyFilters" />
+                <input type="search" class="input" placeholder="Search by name" x-model="filters.search" @input.debounce.200ms="onFiltersChanged" />
               </label>
               </div>
               <div class="filters-footer">

--- a/src/main.js
+++ b/src/main.js
@@ -748,6 +748,9 @@ const v2DashboardAppDefinition = () => ({
   },
   filteredEmployees: [],
   selectedEmployees: [],
+  visibleEmployeeWindow: [],
+  _visibleEmployeeWindowKey: '',
+  _selectAllSyncHandle: null,
   bulk: {
     requirementId: '',
     action: '',
@@ -1012,6 +1015,7 @@ const v2DashboardAppDefinition = () => ({
       value => {
         this.persistFilters(value);
         this.updateUrlFilters(value);
+        this.requestSelectAllSync();
       },
       { deep: true }
     );
@@ -1178,6 +1182,7 @@ const v2DashboardAppDefinition = () => ({
         container.dataset.alpineInitialized = 'true';
       }
       this.hydrateBulkActions();
+      this.requestSelectAllSync();
     });
   },
   hydrateImportDrawer() {
@@ -2152,6 +2157,10 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
     this.employees = this.employees.filter(emp => emp?.id !== employeeId);
     this.filteredEmployees = this.filteredEmployees.filter(emp => emp?.id !== employeeId);
     this.selectedEmployees = this.selectedEmployees.filter(id => id !== employeeId);
+    this.setVisibleEmployeeWindow(
+      this.filteredEmployees.map(emp => emp?.id).filter(id => id !== null && typeof id !== 'undefined')
+    );
+    this.requestSelectAllSync();
 
     if (this.profilePanel.employeeId === employeeId) {
       this.closeProfile();
@@ -2834,9 +2843,13 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
     const requirement = this.requirements.find(req => req.id === this.bulk.requirementId);
     return requirement ? requirement.name : 'Select a requirement';
   },
+  onFiltersChanged() {
+    this.applyFilters();
+  },
   syncSelectedEmployees() {
     if (!Array.isArray(this.selectedEmployees) || this.selectedEmployees.length === 0) {
       this.selectedEmployees = [];
+      this.requestSelectAllSync();
       return;
     }
     const visibleIds = new Set(this.filteredEmployees.map(employee => employee.id));
@@ -2844,6 +2857,53 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
     if (next.length !== this.selectedEmployees.length) {
       this.selectedEmployees = next;
     }
+    this.requestSelectAllSync();
+  },
+  currentVisibleEmployeeIds() {
+    if (Array.isArray(this.visibleEmployeeWindow) && this.visibleEmployeeWindow.length) {
+      return this.visibleEmployeeWindow;
+    }
+    return this.filteredEmployees
+      .map(employee => employee?.id)
+      .filter(id => id !== null && typeof id !== 'undefined');
+  },
+  setVisibleEmployeeWindow(ids) {
+    const normalized = Array.isArray(ids)
+      ? Array.from(new Set(ids.filter(id => id !== null && typeof id !== 'undefined')))
+      : [];
+    const key = normalized.join('|');
+    if (key === this._visibleEmployeeWindowKey) {
+      return;
+    }
+    this._visibleEmployeeWindowKey = key;
+    this.visibleEmployeeWindow = normalized;
+    this.requestSelectAllSync();
+  },
+  handleGridWindowChange(ids) {
+    if (Array.isArray(ids) && ids.length) {
+      this.setVisibleEmployeeWindow(ids);
+    } else if (this.visibleEmployeeWindow.length) {
+      this.setVisibleEmployeeWindow([]);
+    }
+  },
+  requestSelectAllSync() {
+    if (this._selectAllSyncHandle) {
+      clearTimeout(this._selectAllSyncHandle);
+    }
+    this._selectAllSyncHandle = setTimeout(() => {
+      this._selectAllSyncHandle = null;
+      this.$nextTick(() => this.syncSelectAllCheckbox());
+    }, 50);
+  },
+  syncSelectAllCheckbox() {
+    const checkbox = this.$refs?.selectAllCheckbox;
+    if (!checkbox) {
+      return;
+    }
+    const allSelected = this.areAllVisibleSelected();
+    const someSelected = this.hasSomeVisibleSelected();
+    checkbox.checked = allSelected;
+    checkbox.indeterminate = !allSelected && someSelected;
   },
   isEmployeeSelected(employeeId) {
     return this.selectedEmployees.includes(employeeId);
@@ -2856,9 +2916,10 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
     } else if (this.isEmployeeSelected(employeeId)) {
       this.selectedEmployees = this.selectedEmployees.filter(id => id !== employeeId);
     }
+    this.requestSelectAllSync();
   },
   toggleSelectAll(checked) {
-    const visibleIds = this.filteredEmployees.map(employee => employee.id);
+    const visibleIds = this.currentVisibleEmployeeIds();
     if (checked) {
       const unique = new Set([...this.selectedEmployees, ...visibleIds]);
       this.selectedEmployees = Array.from(unique);
@@ -2866,18 +2927,21 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
       const visibleSet = new Set(visibleIds);
       this.selectedEmployees = this.selectedEmployees.filter(id => !visibleSet.has(id));
     }
+    this.requestSelectAllSync();
   },
   areAllVisibleSelected() {
-    if (!this.filteredEmployees.length) {
+    const visibleIds = this.currentVisibleEmployeeIds();
+    if (!visibleIds.length) {
       return false;
     }
-    return this.filteredEmployees.every(employee => this.isEmployeeSelected(employee.id));
+    return visibleIds.every(id => this.isEmployeeSelected(id));
   },
   hasSomeVisibleSelected() {
-    if (!this.filteredEmployees.length) {
+    const visibleIds = this.currentVisibleEmployeeIds();
+    if (!visibleIds.length) {
       return false;
     }
-    return this.filteredEmployees.some(employee => this.isEmployeeSelected(employee.id));
+    return visibleIds.some(id => this.isEmployeeSelected(id));
   },
   clearSelectedEmployees() {
     if (!this.selectedEmployees.length) {
@@ -2885,6 +2949,7 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
     }
     this.selectedEmployees = [];
     this.resetBulkForm({ preserveRequirement: true });
+    this.requestSelectAllSync();
   },
   resetBulkForm(options = {}) {
     const { preserveRequirement = false } = options;
@@ -3503,6 +3568,10 @@ Mehak,BRAICH,LPN,Active,Part-Time,988
       }
       return true;
     });
+    const visibleIds = this.filteredEmployees
+      .map(employee => employee?.id)
+      .filter(id => id !== null && typeof id !== 'undefined');
+    this.setVisibleEmployeeWindow(visibleIds);
     this.updateStoreFilteredEmployees();
     this.syncSelectedEmployees();
   },

--- a/src/v2/requirements-grid.html
+++ b/src/v2/requirements-grid.html
@@ -18,10 +18,27 @@
     </div>
   </template>
 
-  <div class="grid-scroll" role="region" aria-label="Scrollable requirements table" x-show="!loading && filteredEmployees.length">
-    <table class="min-w-full text-sm text-slate-700 requirements-table">
+  <div
+    class="grid-scroll"
+    role="region"
+    aria-label="Scrollable requirements table"
+    x-show="!loading && filteredEmployees.length"
+    x-init="handleGridWindowChange(filteredEmployees.map(employee => employee.id))"
+    @grid-window-changed.window="handleGridWindowChange($event.detail?.visibleIds || [])"
+  >
+    <table class="min-w-full text-sm text-slate-700 requirements-table has-selection-column">
       <thead class="text-xs uppercase tracking-wide text-slate-500">
         <tr>
+          <th scope="col" class="sticky-select sticky-header checkbox-cell">
+            <input
+              type="checkbox"
+              class="checkbox-input"
+              x-ref="selectAllCheckbox"
+              :checked="areAllVisibleSelected()"
+              @change="toggleSelectAll($event.target.checked)"
+              aria-label="Select all visible employees"
+            />
+          </th>
           <th scope="col" class="sticky left-0 z-10 bg-white px-4 py-3 text-left">Employee</th>
           <template x-for="req in gridOrderedRequirements()" :key="req.id">
             <th class="px-4 py-3 text-left whitespace-nowrap" x-text="req.name"></th>
@@ -30,7 +47,17 @@
       </thead>
       <tbody class="divide-y divide-slate-200">
         <template x-for="employee in filteredEmployees" :key="employee.id">
-          <tr class="bg-white">
+          <tr class="bg-white" :class="{ 'row-selected': isEmployeeSelected(employee.id) }">
+            <td class="checkbox-cell sticky-select">
+              <input
+                type="checkbox"
+                class="checkbox-input"
+                :checked="isEmployeeSelected(employee.id)"
+                @change="toggleEmployeeSelection(employee.id, $event.target.checked)"
+                @click.stop
+                :aria-label="`Select ${employee.fullName || (employee.firstName + ' ' + employee.lastName)}`"
+              />
+            </td>
             <th scope="row" class="sticky left-0 z-10 bg-white px-4 py-3 align-top">
               <div class="flex items-start gap-3">
                 <div class="relative h-8 w-8 shrink-0 rounded-full bg-indigo-100 text-indigo-700 grid place-items-center text-xs font-semibold">


### PR DESCRIPTION
## Summary
- add a selection column with select-all control to the requirements grid and listen for window change events
- debounce select-all state updates while tracking the visible employee window in the store
- route filter toolbar events through a handler that reapplies filters so selection state recomputes after filter changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2077d9f788327874e3c20f69ccf1f